### PR TITLE
feat: fidelis sessions — searchable, purge-able session memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ export FIDELIS_SESSIONS_EXCLUDE="client-acme,secrets"
 fidelis sessions ingest
 ```
 
+### Privacy & storage
+
+- **What is stored, where:** `ingest` writes a copy of your session conversation text into a local ChromaDB store at `~/.cogito/store`. The full per-turn conversation text is retained in metadata (`turns_json`). Embeddings are produced locally by Ollama; nothing is uploaded.
+- **How it's protected:** the stored text is **not application-encrypted.** `ingest` sets `chmod 700` on `~/.cogito` (readable only by your OS user); pair that with full-disk encryption (FileVault) for at-rest protection.
+- **Deletion stops at the index:** `purge` removes the index records (text, embeddings, metadata) for matched sessions. It never touches your source files in `~/.claude/projects` or backups in `~/Backups/claude-sessions`.
+- **Keep sensitive projects out:** use `FIDELIS_SESSIONS_EXCLUDE` (above) to never index them in the first place.
+
+See [SECURITY.md](SECURITY.md) for full detail.
+
 Python helper for direct integration:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -193,10 +193,19 @@ fidelis sessions purge --all --dry-run       # preview what would be removed
 
 **Deletion stops at the index.** `purge` removes sessions from fidelis's search index only. It never touches your source files in `~/.claude/projects` or backups in `~/Backups/claude-sessions` - those are left alone by design. `purge` prompts before deleting unless you pass `--yes`.
 
-**Keep sensitive projects out entirely.** The honest pre-ingest privacy lever is the deny-list: set `FIDELIS_SESSIONS_EXCLUDE` to a comma-separated list of substrings, and any project whose path contains one is never indexed.
+**Pick your privacy posture once.** `FIDELIS_SESSIONS_MODE` chooses how `ingest` decides what to read (set it via the env var, or the `sessions_mode` key in `~/.cogito/config.json` — the env var wins):
+
+- `opt-out` (default): index everything **except** the deny-list. Use `FIDELIS_SESSIONS_EXCLUDE`, a comma-separated list of substrings; any project whose path contains one is never indexed.
+- `opt-in`: index **nothing except** the allow-list. Use `FIDELIS_SESSIONS_INCLUDE`, a comma-separated list of substrings; only projects whose path contains one are indexed. With an empty allow-list nothing is indexed and `ingest` tells you to set it.
 
 ```bash
+# opt-out (default): index all but the named projects
 export FIDELIS_SESSIONS_EXCLUDE="client-acme,secrets"
+fidelis sessions ingest
+
+# opt-in: index only the named projects
+export FIDELIS_SESSIONS_MODE=opt-in
+export FIDELIS_SESSIONS_INCLUDE="hermes,langquant"
 fidelis sessions ingest
 ```
 
@@ -205,7 +214,7 @@ fidelis sessions ingest
 - **What is stored, where:** `ingest` writes a copy of your session conversation text into a local ChromaDB store at `~/.cogito/store`. The full per-turn conversation text is retained in metadata (`turns_json`). Embeddings are produced locally by Ollama; nothing is uploaded.
 - **How it's protected:** the stored text is **not application-encrypted.** `ingest` sets `chmod 700` on `~/.cogito` (readable only by your OS user); pair that with full-disk encryption (FileVault) for at-rest protection.
 - **Deletion stops at the index:** `purge` removes the index records (text, embeddings, metadata) for matched sessions. It never touches your source files in `~/.claude/projects` or backups in `~/Backups/claude-sessions`.
-- **Keep sensitive projects out:** use `FIDELIS_SESSIONS_EXCLUDE` (above) to never index them in the first place.
+- **Keep sensitive projects out:** in opt-out mode use `FIDELIS_SESSIONS_EXCLUDE` (above) to never index them; or set `FIDELIS_SESSIONS_MODE=opt-in` and name only what you want via `FIDELIS_SESSIONS_INCLUDE` so nothing else is ever read.
 
 See [SECURITY.md](SECURITY.md) for full detail.
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,35 @@ fidelis health
 fidelis seed   ~/memory/   ~/notes/
 ```
 
+## Search your Claude Code session history
+
+`fidelis sessions` indexes your past Claude Code conversations (the JSONL files Claude Code writes under `~/.claude/projects/`) so you can search what you actually said and decided across sessions. Same zero-LLM retrieval path - searchable, best on multi-turn queries.
+
+```bash
+fidelis sessions ingest                 # index the last 7 days
+fidelis sessions ingest --since 2026-05-01
+fidelis sessions ingest --all           # index everything
+fidelis sessions ingest --dry-run       # preview, write nothing
+
+fidelis sessions search "what did we decide about auth"
+fidelis sessions search "auth" --limit 5 --raw   # JSON output
+
+fidelis sessions list                   # indexed sessions
+fidelis sessions stats                  # corpus stats
+
+fidelis sessions purge --before 2026-04-01   # remove old sessions from the index
+fidelis sessions purge --all --dry-run       # preview what would be removed
+```
+
+**Deletion stops at the index.** `purge` removes sessions from fidelis's search index only. It never touches your source files in `~/.claude/projects` or backups in `~/Backups/claude-sessions` - those are left alone by design. `purge` prompts before deleting unless you pass `--yes`.
+
+**Keep sensitive projects out entirely.** The honest pre-ingest privacy lever is the deny-list: set `FIDELIS_SESSIONS_EXCLUDE` to a comma-separated list of substrings, and any project whose path contains one is never indexed.
+
+```bash
+export FIDELIS_SESSIONS_EXCLUDE="client-acme,secrets"
+fidelis sessions ingest
+```
+
 Python helper for direct integration:
 
 ```python

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security & Privacy
+
+This document covers how fidelis handles your data, with specific detail on the
+`fidelis sessions` feature, which indexes your Claude Code conversation history.
+
+## Reporting a vulnerability
+
+If you find a security issue, please open a private report via GitHub Security
+Advisories on the repository, or email the maintainers. Please do not file public
+issues for vulnerabilities.
+
+## What `fidelis sessions` stores, and where
+
+`fidelis sessions ingest` reads your Claude Code session files
+(`~/.claude/projects/*/SESSION_ID.jsonl`) and writes a searchable copy into a
+**local** ChromaDB store at `~/.cogito/store`.
+
+Each indexed session is stored with:
+
+- the **full conversation text** of the session's turns, retained in the
+  `turns_json` metadata field (user and assistant turns, up to 100 turns per
+  session);
+- a flat text representation used as the embedding document and for retrieval
+  display;
+- metadata: session id, project path, turn count, and timestamps.
+
+There are no cloud calls in the default path: embeddings are produced locally by
+Ollama (`nomic-embed-text`) and stored locally by ChromaDB. Nothing is uploaded.
+
+A dedup ledger and purge log live alongside the store at
+`~/.cogito/session_ingest/`.
+
+## How the stored data is protected
+
+The session text is **not application-encrypted at rest.** It is plain text
+inside a local ChromaDB store. Protection relies on:
+
+- **Filesystem permissions.** Ingest sets `chmod 700` on `~/.cogito`, so the
+  directory is readable only by your OS user.
+- **Full-disk encryption (FileVault on macOS, or your platform's equivalent).**
+  Enable it. It is your at-rest encryption for this data.
+
+If you share an account, run on a multi-user machine, or do not have full-disk
+encryption, treat the contents of `~/.cogito` as readable plain text.
+
+## Keeping sensitive projects out (pre-ingest lever)
+
+The honest privacy lever is to **not index** sensitive projects in the first
+place. Set `FIDELIS_SESSIONS_EXCLUDE` to a comma-separated list of substrings;
+any project whose path contains one of them is never read or indexed:
+
+```bash
+export FIDELIS_SESSIONS_EXCLUDE="client-acme,secrets"
+fidelis sessions ingest --all
+```
+
+This is also documented in `fidelis sessions ingest --help`.
+
+## Deletion stops at the index
+
+`fidelis sessions purge` removes matched sessions from the search index — their
+text, embeddings, and metadata records — and cleans the dedup ledger entry.
+
+Purge **never** touches your original Claude Code session files in
+`~/.claude/projects` or any backups in `~/Backups/claude-sessions`. Those are
+left alone by design. Purge prompts for confirmation unless you pass `--yes`.
+
+To remove the entire store:
+
+```bash
+rm -rf ~/.cogito ~/.fidelis
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,11 +46,28 @@ encryption, treat the contents of `~/.cogito` as readable plain text.
 ## Keeping sensitive projects out (pre-ingest lever)
 
 The honest privacy lever is to **not index** sensitive projects in the first
-place. Set `FIDELIS_SESSIONS_EXCLUDE` to a comma-separated list of substrings;
-any project whose path contains one of them is never read or indexed:
+place. You pick the posture once with `FIDELIS_SESSIONS_MODE` (read from the env
+var, or the `sessions_mode` key in `~/.cogito/config.json`; the env var wins).
+The default is `opt-out`.
+
+**opt-out (default) — deny-list.** Index everything *except* named projects.
+Set `FIDELIS_SESSIONS_EXCLUDE` to a comma-separated list of substrings; any
+project whose path contains one of them is never read or indexed:
 
 ```bash
 export FIDELIS_SESSIONS_EXCLUDE="client-acme,secrets"
+fidelis sessions ingest --all
+```
+
+**opt-in — allow-list.** Index *nothing except* named projects. Set
+`FIDELIS_SESSIONS_MODE=opt-in` and name what to index with
+`FIDELIS_SESSIONS_INCLUDE` (same comma-separated substring mechanism); only
+matching projects are read. With an empty allow-list nothing is indexed and
+`ingest` prints a message telling you to set it (it never silently does nothing):
+
+```bash
+export FIDELIS_SESSIONS_MODE=opt-in
+export FIDELIS_SESSIONS_INCLUDE="hermes,langquant"
 fidelis sessions ingest --all
 ```
 

--- a/src/fidelis/cli.py
+++ b/src/fidelis/cli.py
@@ -310,6 +310,41 @@ def main():
     p_mcp_uninstall.add_argument("--settings", help="Path to settings.local.json")
     p_mcp_uninstall.set_defaults(func=lambda a: sys.exit(_cmd_mcp_uninstall(a)))
 
+    # sessions — searchable, purge-able Claude Code session memory (MVP-A)
+    p_sessions = sub.add_parser("sessions", help="Search/manage your Claude Code session history")
+    sess_sub = p_sessions.add_subparsers(dest="sessions_command", required=True)
+
+    s_ingest = sess_sub.add_parser("ingest", help="Index sessions (default: last 7 days)")
+    g = s_ingest.add_mutually_exclusive_group()
+    g.add_argument("--since", help="Index sessions since YYYY-MM-DD")
+    g.add_argument("--all", action="store_true", help="Index all sessions")
+    s_ingest.add_argument("--dry-run", action="store_true", help="Preview, write nothing")
+    s_ingest.add_argument("--verbose", "-v", action="store_true")
+    s_ingest.set_defaults(func=lambda a: sys.exit(_cmd_sessions_ingest(a)))
+
+    s_search = sess_sub.add_parser("search", help="Search session history")
+    s_search.add_argument("query", help="Natural-language query")
+    s_search.add_argument("--limit", type=int, default=5)
+    s_search.add_argument("--raw", action="store_true", help="JSON output (no turns)")
+    s_search.set_defaults(func=lambda a: sys.exit(_cmd_sessions_search(a)))
+
+    s_list = sess_sub.add_parser("list", help="List indexed sessions")
+    s_list.add_argument("--since", help="Only since YYYY-MM-DD")
+    s_list.add_argument("--limit", type=int, default=50)
+    s_list.set_defaults(func=lambda a: sys.exit(_cmd_sessions_list(a)))
+
+    s_purge = sess_sub.add_parser("purge", help="Delete sessions from the index (NOT source/backups)")
+    pg = s_purge.add_mutually_exclusive_group(required=True)
+    pg.add_argument("--all", action="store_true", help="Purge every indexed session")
+    pg.add_argument("--before", help="Purge sessions older than YYYY-MM-DD")
+    s_purge.add_argument("--dry-run", action="store_true", help="Preview, write nothing")
+    s_purge.add_argument("--yes", action="store_true", help="Skip confirmation prompt")
+    s_purge.set_defaults(func=lambda a: sys.exit(_cmd_sessions_purge(a)))
+
+    s_stats = sess_sub.add_parser("stats", help="Corpus stats for indexed sessions")
+    s_stats.add_argument("--since", help="Only since YYYY-MM-DD")
+    s_stats.set_defaults(func=lambda a: sys.exit(_cmd_sessions_stats(a)))
+
     args = parser.parse_args()
     args.func(args)
 
@@ -335,6 +370,31 @@ def _cmd_mcp_install(args):
 def _cmd_mcp_uninstall(args):
     from fidelis.mcp_cmd import cmd_mcp_uninstall
     return cmd_mcp_uninstall(args)
+
+
+def _cmd_sessions_ingest(args):
+    from fidelis.sessions_cmd import cmd_ingest
+    return cmd_ingest(args)
+
+
+def _cmd_sessions_search(args):
+    from fidelis.sessions_cmd import cmd_search
+    return cmd_search(args)
+
+
+def _cmd_sessions_list(args):
+    from fidelis.sessions_cmd import cmd_list
+    return cmd_list(args)
+
+
+def _cmd_sessions_purge(args):
+    from fidelis.sessions_cmd import cmd_purge
+    return cmd_purge(args)
+
+
+def _cmd_sessions_stats(args):
+    from fidelis.sessions_cmd import cmd_stats
+    return cmd_stats(args)
 
 
 if __name__ == "__main__":

--- a/src/fidelis/cli.py
+++ b/src/fidelis/cli.py
@@ -319,13 +319,27 @@ def main():
         help="Index sessions (default: last 7 days)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "Privacy lever:\n"
-            "  FIDELIS_SESSIONS_EXCLUDE  comma-separated substring deny-list. Any\n"
-            "                            project whose path contains one of these\n"
-            "                            substrings is never indexed (pre-ingest).\n"
+            "Privacy posture (pick once):\n"
+            "  FIDELIS_SESSIONS_MODE     opt-out (default) | opt-in. Also read from\n"
+            "                            ~/.cogito/config.json key 'sessions_mode';\n"
+            "                            the env var wins. opt-out indexes everything\n"
+            "                            except the deny-list; opt-in indexes nothing\n"
+            "                            except the allow-list.\n"
             "\n"
-            "  Example:\n"
+            "Privacy levers:\n"
+            "  FIDELIS_SESSIONS_EXCLUDE  comma-separated substring deny-list (opt-out\n"
+            "                            mode). Any project whose path contains one of\n"
+            "                            these substrings is never indexed (pre-ingest).\n"
+            "  FIDELIS_SESSIONS_INCLUDE  comma-separated substring allow-list (opt-in\n"
+            "                            mode). ONLY projects whose path contains one of\n"
+            "                            these substrings are indexed; empty = nothing.\n"
+            "\n"
+            "  Examples:\n"
             '    export FIDELIS_SESSIONS_EXCLUDE="client-acme,secrets"\n'
+            "    fidelis sessions ingest --all\n"
+            "\n"
+            '    export FIDELIS_SESSIONS_MODE=opt-in\n'
+            '    export FIDELIS_SESSIONS_INCLUDE="hermes,langquant"\n'
             "    fidelis sessions ingest --all\n"
         ),
     )

--- a/src/fidelis/cli.py
+++ b/src/fidelis/cli.py
@@ -314,7 +314,21 @@ def main():
     p_sessions = sub.add_parser("sessions", help="Search/manage your Claude Code session history")
     sess_sub = p_sessions.add_subparsers(dest="sessions_command", required=True)
 
-    s_ingest = sess_sub.add_parser("ingest", help="Index sessions (default: last 7 days)")
+    s_ingest = sess_sub.add_parser(
+        "ingest",
+        help="Index sessions (default: last 7 days)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Privacy lever:\n"
+            "  FIDELIS_SESSIONS_EXCLUDE  comma-separated substring deny-list. Any\n"
+            "                            project whose path contains one of these\n"
+            "                            substrings is never indexed (pre-ingest).\n"
+            "\n"
+            "  Example:\n"
+            '    export FIDELIS_SESSIONS_EXCLUDE="client-acme,secrets"\n'
+            "    fidelis sessions ingest --all\n"
+        ),
+    )
     g = s_ingest.add_mutually_exclusive_group()
     g.add_argument("--since", help="Index sessions since YYYY-MM-DD")
     g.add_argument("--all", action="store_true", help="Index all sessions")

--- a/src/fidelis/ingest_claude_sessions.py
+++ b/src/fidelis/ingest_claude_sessions.py
@@ -280,7 +280,14 @@ def ingest(
 
     stats = {"scanned": 0, "skipped_dedup": 0, "skipped_empty": 0, "stored": 0, "errors": 0}
 
-    for session_id, jsonl_path, project_path in _iter_sessions(since=since, exclude=exclude):
+    # B2: progress signal. Counting candidates up front turns a silent multi-minute
+    # run (which reads like a freeze) into "Indexing N sessions …". Materialise the
+    # generator once so we can both count and iterate without re-walking the tree.
+    candidates = list(_iter_sessions(since=since, exclude=exclude))
+    label = "would index" if dry_run else "Indexing"
+    print(f"{label} {len(candidates)} sessions (this may take a few minutes)…")
+
+    for session_id, jsonl_path, project_path in candidates:
         stats["scanned"] += 1
 
         turns = _parse_jsonl(jsonl_path)

--- a/src/fidelis/ingest_claude_sessions.py
+++ b/src/fidelis/ingest_claude_sessions.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sys
 import urllib.request
 import uuid
@@ -115,10 +116,28 @@ def _parse_jsonl(path: Path) -> list[dict]:
 
 # ── Session Discovery ─────────────────────────────────────────────────────────
 
-def _iter_sessions(since: datetime | None = None) -> Iterator[tuple[str, Path, str]]:
+def _excluded(project_path: str, exclude: list[str] | None) -> bool:
+    """Project-level deny-list: skip any project whose name contains an excluded
+    substring. The only honest *pre-ingest* privacy lever — excluded projects
+    are never indexed at all. Pure function so it is testable without services."""
+    if not exclude:
+        return False
+    return any(token and token in project_path for token in exclude)
+
+
+def _load_exclude() -> list[str]:
+    """Deny-list from FIDELIS_SESSIONS_EXCLUDE (comma-separated) env var."""
+    raw = os.environ.get("FIDELIS_SESSIONS_EXCLUDE", "")
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def _iter_sessions(
+    since: datetime | None = None,
+    exclude: list[str] | None = None,
+) -> Iterator[tuple[str, Path, str]]:
     """
     Yield (session_id, jsonl_path, project_path) for all Claude Code sessions.
-    Filters by since if given.
+    Filters by since if given; skips projects matching the deny-list (exclude).
     """
     if not CLAUDE_PROJECTS.exists():
         return
@@ -127,6 +146,9 @@ def _iter_sessions(since: datetime | None = None) -> Iterator[tuple[str, Path, s
         if not project_dir.is_dir():
             continue
         project_path = project_dir.name  # e.g. '-Users-rbr-lpci'
+
+        if _excluded(project_path, exclude):
+            continue
 
         for jsonl_file in project_dir.glob("*.jsonl"):
             session_id = jsonl_file.stem
@@ -235,18 +257,30 @@ def ingest(
     since: datetime | None = None,
     dry_run: bool = False,
     verbose: bool = False,
+    exclude: list[str] | None = None,
 ) -> dict:
     """
     Ingest Claude Code sessions into cogito.
 
+    exclude: project-name substrings to skip (deny-list). Falls back to the
+    FIDELIS_SESSIONS_EXCLUDE env var when not passed.
+
     Returns stats dict: {scanned, skipped_dedup, skipped_empty, stored, errors}
     """
+    if exclude is None:
+        exclude = _load_exclude()
     ledger = _load_ledger()
     col = None if dry_run else _get_collection()
+    if not dry_run:
+        # Defensive: make the local store OS-user-private even if `init` was skipped.
+        try:
+            os.chmod(Path.home() / ".cogito", 0o700)
+        except OSError:  # noqa: best-effort; store may not exist yet on first run
+            pass
 
     stats = {"scanned": 0, "skipped_dedup": 0, "skipped_empty": 0, "stored": 0, "errors": 0}
 
-    for session_id, jsonl_path, project_path in _iter_sessions(since=since):
+    for session_id, jsonl_path, project_path in _iter_sessions(since=since, exclude=exclude):
         stats["scanned"] += 1
 
         turns = _parse_jsonl(jsonl_path)

--- a/src/fidelis/ingest_claude_sessions.py
+++ b/src/fidelis/ingest_claude_sessions.py
@@ -131,13 +131,62 @@ def _load_exclude() -> list[str]:
     return [t.strip() for t in raw.split(",") if t.strip()]
 
 
+def _included(project_path: str, include: list[str] | None) -> bool:
+    """Project-level allow-list (opt-in mode): a project is indexed only if its
+    name contains an included substring. Mirror image of _excluded(). Pure
+    function so it is testable without services. With an empty/None allow-list
+    nothing matches — opt-in indexes nothing until the user names projects."""
+    if not include:
+        return False
+    return any(token and token in project_path for token in include)
+
+
+def _load_include() -> list[str]:
+    """Allow-list from FIDELIS_SESSIONS_INCLUDE (comma-separated) env var."""
+    raw = os.environ.get("FIDELIS_SESSIONS_INCLUDE", "")
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def _load_mode() -> str:
+    """Ingest privacy posture: 'opt-out' (default) indexes everything except the
+    deny-list; 'opt-in' indexes nothing except the allow-list. Read from the
+    FIDELIS_SESSIONS_MODE env var, else the 'sessions_mode' key in
+    ~/.cogito/config.json, else 'opt-out'. Env wins over file (matches config.py).
+    Unrecognised values fall back to 'opt-out' (the safe, behaviour-preserving
+    default)."""
+    valid = ("opt-in", "opt-out")
+
+    env = os.environ.get("FIDELIS_SESSIONS_MODE", "").strip().lower()
+    if env in valid:
+        return env
+
+    config_path = Path.home() / ".cogito" / "config.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text())
+            file_mode = str(file_cfg.get("sessions_mode", "")).strip().lower()
+            if file_mode in valid:
+                return file_mode
+        except Exception:  # noqa: silent — malformed config falls back to default
+            pass
+
+    return "opt-out"
+
+
 def _iter_sessions(
     since: datetime | None = None,
     exclude: list[str] | None = None,
+    mode: str = "opt-out",
+    include: list[str] | None = None,
 ) -> Iterator[tuple[str, Path, str]]:
     """
     Yield (session_id, jsonl_path, project_path) for all Claude Code sessions.
-    Filters by since if given; skips projects matching the deny-list (exclude).
+    Filters by since if given.
+
+    Privacy posture:
+      • opt-out (default): skip projects matching the deny-list (exclude).
+      • opt-in: yield ONLY projects matching the allow-list (include); with an
+        empty allow-list nothing is yielded.
     """
     if not CLAUDE_PROJECTS.exists():
         return
@@ -147,8 +196,12 @@ def _iter_sessions(
             continue
         project_path = project_dir.name  # e.g. '-Users-rbr-lpci'
 
-        if _excluded(project_path, exclude):
-            continue
+        if mode == "opt-in":
+            if not _included(project_path, include):
+                continue
+        else:
+            if _excluded(project_path, exclude):
+                continue
 
         for jsonl_file in project_dir.glob("*.jsonl"):
             session_id = jsonl_file.stem
@@ -258,17 +311,37 @@ def ingest(
     dry_run: bool = False,
     verbose: bool = False,
     exclude: list[str] | None = None,
+    mode: str | None = None,
+    include: list[str] | None = None,
 ) -> dict:
     """
     Ingest Claude Code sessions into cogito.
 
-    exclude: project-name substrings to skip (deny-list). Falls back to the
-    FIDELIS_SESSIONS_EXCLUDE env var when not passed.
+    mode: privacy posture, 'opt-out' (default) or 'opt-in'. Falls back to
+    _load_mode() (FIDELIS_SESSIONS_MODE env / config.json) when not passed.
+    exclude: project-name substrings to skip (deny-list), used in opt-out mode.
+    Falls back to the FIDELIS_SESSIONS_EXCLUDE env var when not passed.
+    include: project-name substrings to allow (allow-list), used in opt-in mode.
+    Falls back to the FIDELIS_SESSIONS_INCLUDE env var when not passed.
 
     Returns stats dict: {scanned, skipped_dedup, skipped_empty, stored, errors}
     """
+    if mode is None:
+        mode = _load_mode()
     if exclude is None:
         exclude = _load_exclude()
+    if include is None:
+        include = _load_include()
+
+    # Opt-in onboarding: an empty allow-list would silently index nothing, which
+    # reads like a broken run during setup. Say so explicitly and stop early.
+    if mode == "opt-in" and not include:
+        print(
+            "opt-in mode: no projects included yet — set FIDELIS_SESSIONS_INCLUDE=... "
+            "to choose what to index"
+        )
+        return {"scanned": 0, "skipped_dedup": 0, "skipped_empty": 0, "stored": 0, "errors": 0}
+
     ledger = _load_ledger()
     col = None if dry_run else _get_collection()
     if not dry_run:
@@ -283,7 +356,7 @@ def ingest(
     # B2: progress signal. Counting candidates up front turns a silent multi-minute
     # run (which reads like a freeze) into "Indexing N sessions …". Materialise the
     # generator once so we can both count and iterate without re-walking the tree.
-    candidates = list(_iter_sessions(since=since, exclude=exclude))
+    candidates = list(_iter_sessions(since=since, exclude=exclude, mode=mode, include=include))
     label = "would index" if dry_run else "Indexing"
     print(f"{label} {len(candidates)} sessions (this may take a few minutes)…")
 

--- a/src/fidelis/sessions_cmd.py
+++ b/src/fidelis/sessions_cmd.py
@@ -1,0 +1,209 @@
+"""
+fidelis sessions — searchable, purge-able session memory (MVP-A).
+
+Wraps existing capability (query_sessions, ingest) and adds the purge path.
+Honesty rules (non-negotiable, carried from the v1 spec):
+  • Never print retrieval-benchmark numbers in product output (label only:
+    "searchable session history — best on multi-turn queries").
+  • Deletion claims stop at the INDEX. Source files in ~/.claude/projects and
+    backups in ~/Backups/claude-sessions are NEVER touched.
+  • No redaction-as-privacy-control. The honest levers are: don't-index
+    (deny-list / --dry-run) and delete-after (purge).
+
+Pure helpers (_iso_before, _collect_purge_targets, _filter_before) are separated
+so they can be tested without a live ChromaDB / Ollama — "experiential contact"
+with the LOGIC, not the services.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+COGITO_SESSIONS_DIR = Path.home() / ".cogito" / "session_ingest"
+
+BACKUP_BOUNDARY = (
+    "Source files in ~/.claude/projects and backups in ~/Backups/claude-sessions "
+    "are NOT touched by design."
+)
+PRIVACY_NOTICE = (
+    "Note: sessions contain full conversation history, stored locally in ~/.cogito "
+    "(readable only by your user). Run `fidelis sessions purge` to remove. " + BACKUP_BOUNDARY
+)
+
+
+# ── Pure helpers (testable without services) ──────────────────────────────────
+
+def _iso_before(end_ts: str, before: str) -> bool:
+    """True if end_ts is strictly before the `before` date (YYYY-MM-DD).
+    ISO-8601 lexicographic comparison is valid for the stored `...Z` format,
+    so we avoid ChromaDB's broken string `$lt` where-filter entirely."""
+    if not end_ts:
+        return False
+    return end_ts[:10] < before[:10]
+
+
+def _collect_purge_targets(
+    metadatas: list[dict], ids: list[str], mode: str, before: str | None
+) -> tuple[list[str], list[str]]:
+    """Return (target_ids, target_hashes) for purge. Pure: takes already-fetched
+    ChromaDB rows, never calls the DB. mode is 'all' or 'before'.
+    Collects ingest_hash too — required for ledger cleanup (spec step 3)."""
+    target_ids: list[str] = []
+    target_hashes: list[str] = []
+    for cid, meta in zip(ids, metadatas):
+        if mode == "all":
+            keep = True
+        elif mode == "before":
+            keep = _iso_before(meta.get("end_ts", ""), before or "")
+        else:
+            keep = False
+        if keep:
+            target_ids.append(cid)
+            h = meta.get("ingest_hash")
+            if h:
+                target_hashes.append(h)
+    return target_ids, target_hashes
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── purge (the locked contract — §4 of the v1 spec) ───────────────────────────
+
+def cmd_purge(args) -> int:
+    if bool(args.all) == bool(args.before):
+        print("Error: pass exactly one of --all or --before YYYY-MM-DD")
+        return 2
+
+    from fidelis.ingest_claude_sessions import _get_collection  # lazy: avoids chromadb import at CLI start
+
+    col = _get_collection()
+    entries = col.get(where={"mem_type": "session"}, include=["metadatas"])
+    ids = entries.get("ids", []) or []
+    metas = entries.get("metadatas", []) or []
+
+    mode = "all" if args.all else "before"
+    target_ids, target_hashes = _collect_purge_targets(metas, ids, mode, args.before)
+
+    if not target_ids:
+        print("No matching sessions to purge.")
+        return 0
+
+    # oldest/newest for the confirmation summary
+    ends = sorted(m.get("end_ts", "") for m in metas if m.get("end_ts"))
+    span = f"{ends[0][:10]}..{ends[-1][:10]}" if ends else "unknown"
+
+    if args.dry_run:
+        print(f"DRY-RUN: would remove {len(target_ids)} sessions (span {span}). Nothing written.")
+        print(BACKUP_BOUNDARY)
+        return 0
+
+    if not args.yes:
+        print(f"About to remove {len(target_ids)} sessions from the search index (span {span}).")
+        print(BACKUP_BOUNDARY)
+        resp = input(f"Delete {len(target_ids)} sessions? [y/N] ").strip().lower()
+        if resp != "y":  # default N — accidental Enter must not delete
+            print("Aborted.")
+            return 1
+
+    col.delete(ids=target_ids)
+
+    # ledger cleanup: ingested.json maps {ingest_hash: chroma_id}
+    ledger_path = COGITO_SESSIONS_DIR / "ingested.json"
+    if ledger_path.exists():
+        try:
+            ledger = json.loads(ledger_path.read_text())
+            for h in target_hashes:
+                ledger.pop(h, None)
+            ledger_path.write_text(json.dumps(ledger, indent=2))
+        except Exception:  # noqa: best-effort; index delete already happened
+            pass
+
+    # append purge log
+    COGITO_SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+    with open(COGITO_SESSIONS_DIR / "purge_log.jsonl", "a") as f:
+        f.write(json.dumps({
+            "ts": _now_iso(), "mode": mode, "count": len(target_ids),
+            "session_ids": target_ids,
+        }) + "\n")
+
+    print(f"Removed {len(target_ids)} sessions from the search index. {BACKUP_BOUNDARY}")
+    return 0
+
+
+# ── ingest / search / list / stats (thin wrappers over existing code) ─────────
+
+def cmd_ingest(args) -> int:
+    from fidelis.ingest_claude_sessions import ingest
+    from datetime import datetime as _dt, timezone as _tz
+    since = None
+    if not args.all:
+        # default: last 7 days (spec) unless --since given
+        if args.since:
+            since = _dt.fromisoformat(args.since).replace(tzinfo=_tz.utc)
+        else:
+            from datetime import timedelta
+            since = _dt.now(_tz.utc) - timedelta(days=7)
+    stats = ingest(since=since, dry_run=args.dry_run, verbose=args.verbose)
+    print(f"scanned={stats['scanned']} stored={stats['stored']} "
+          f"skipped_dedup={stats['skipped_dedup']} skipped_empty={stats['skipped_empty']} "
+          f"errors={stats['errors']}")
+    if not args.dry_run:
+        print(PRIVACY_NOTICE)
+    return 0
+
+
+def cmd_search(args) -> int:
+    from fidelis.recall_sessions import query_sessions
+    results = query_sessions(args.query, top_k=args.limit)
+    if args.raw:
+        print(json.dumps([r.to_dict() for r in results], indent=2))
+        return 0
+    if not results:
+        print("No matching sessions. (searchable session history — best on multi-turn queries)")
+        return 0
+    for i, r in enumerate(results, 1):
+        print(f"[{i}] score {r.score:.4f}  {r.start_ts[:10]}  {r.turn_count} turns  {r.project_path}")
+        print(f"    {r.matched_chunk}")
+    return 0
+
+
+def cmd_list(args) -> int:
+    from fidelis.ingest_claude_sessions import _get_collection
+    col = _get_collection()
+    entries = col.get(where={"mem_type": "session"}, include=["metadatas"])
+    metas = entries.get("metadatas", []) or []
+    rows = sorted(metas, key=lambda m: m.get("start_ts", ""))
+    if args.since:
+        rows = [m for m in rows if m.get("start_ts", "")[:10] >= args.since[:10]]
+    rows = rows[: args.limit]
+    for m in rows:
+        print(f"{m.get('start_ts','')[:10]}  {m.get('session_id','')[:8]}  "
+              f"{m.get('turn_count','?')} turns  {m.get('project_path','')}")
+    print(f"\n{len(rows)} sessions.")
+    return 0
+
+
+def cmd_stats(args) -> int:
+    from fidelis.ingest_claude_sessions import _get_collection
+    col = _get_collection()
+    entries = col.get(where={"mem_type": "session"}, include=["metadatas"])
+    metas = entries.get("metadatas", []) or []
+    if not metas:
+        print("No sessions indexed. Run `fidelis sessions ingest`.")
+        return 0
+    total_turns = sum(int(m.get("turn_count", 0) or 0) for m in metas)
+    ends = sorted(m.get("end_ts", "") for m in metas if m.get("end_ts"))
+    projects: dict[str, int] = {}
+    for m in metas:
+        projects[m.get("project_path", "?")] = projects.get(m.get("project_path", "?"), 0) + 1
+    print(f"indexed sessions: {len(metas)}")
+    print(f"date range: {ends[0][:10] if ends else '?'} .. {ends[-1][:10] if ends else '?'}")
+    print(f"total turns: {total_turns}  avg/session: {total_turns // max(len(metas),1)}")
+    print("by project:")
+    for p, n in sorted(projects.items(), key=lambda x: -x[1])[:10]:
+        print(f"  {n:>5}  {p}")
+    print("\nTool/skill call breakdown is not available in this version.")
+    return 0

--- a/src/fidelis/sessions_cmd.py
+++ b/src/fidelis/sessions_cmd.py
@@ -91,8 +91,13 @@ def cmd_purge(args) -> int:
         print("No matching sessions to purge.")
         return 0
 
-    # oldest/newest for the confirmation summary
-    ends = sorted(m.get("end_ts", "") for m in metas if m.get("end_ts"))
+    # oldest/newest of the MATCHED set (not the whole corpus) for an honest summary
+    target_set = set(target_ids)
+    ends = sorted(
+        m.get("end_ts", "")
+        for cid, m in zip(ids, metas)
+        if cid in target_set and m.get("end_ts")
+    )
     span = f"{ends[0][:10]}..{ends[-1][:10]}" if ends else "unknown"
 
     if args.dry_run:

--- a/src/fidelis/sessions_cmd.py
+++ b/src/fidelis/sessions_cmd.py
@@ -140,10 +140,21 @@ def cmd_purge(args) -> int:
 
 # ── ingest / search / list / stats (thin wrappers over existing code) ─────────
 
+def _is_first_run() -> bool:
+    """First-run = no dedup ledger yet (nothing has ever been ingested).
+    Reads the on-disk ledger, so it works without a live ChromaDB/Ollama."""
+    from fidelis.ingest_claude_sessions import _load_ledger
+    try:
+        return not _load_ledger()
+    except Exception:  # noqa: best-effort; a missing/corrupt ledger means first run
+        return True
+
+
 def cmd_ingest(args) -> int:
     from fidelis.ingest_claude_sessions import ingest
     from datetime import datetime as _dt, timezone as _tz
     since = None
+    default_window = False
     if not args.all:
         # default: last 7 days (spec) unless --since given
         if args.since:
@@ -151,6 +162,19 @@ def cmd_ingest(args) -> int:
         else:
             from datetime import timedelta
             since = _dt.now(_tz.utc) - timedelta(days=7)
+            default_window = True
+
+    # B3: the pitch is "keep & search your sessions", but the default sweep is only
+    # 7 days. On a first run that silently leaves all older history un-indexed. Nudge
+    # (don't silently change the default): tell the user older sessions exist and how
+    # to get them, without over-engineering a full-history scan into the default path.
+    if default_window and _is_first_run():
+        print(
+            "First run: indexing only the last 7 days. Your older Claude Code "
+            "sessions are NOT indexed yet — run `fidelis sessions ingest --all` "
+            "to index your full history."
+        )
+
     stats = ingest(since=since, dry_run=args.dry_run, verbose=args.verbose)
     print(f"scanned={stats['scanned']} stored={stats['stored']} "
           f"skipped_dedup={stats['skipped_dedup']} skipped_empty={stats['skipped_empty']} "

--- a/tests/test_sessions_mvp_a.py
+++ b/tests/test_sessions_mvp_a.py
@@ -91,3 +91,72 @@ def test_no_benchmark_numbers_in_product_strings():
 def test_privacy_notice_mentions_local_and_purge():
     assert "~/.cogito" in S.PRIVACY_NOTICE
     assert "purge" in S.PRIVACY_NOTICE
+
+
+# ── B2: ingest progress signal (no silent multi-minute "hang") ────────────────
+
+class _IngestArgs:
+    def __init__(self, all=False, since=None, dry_run=True, verbose=False):
+        self.all = all
+        self.since = since
+        self.dry_run = dry_run
+        self.verbose = verbose
+
+
+def test_ingest_prints_candidate_count_up_front(capsys, monkeypatch):
+    # B2: before the loop, ingest() must announce how many sessions it will index
+    # so a long run doesn't read as a freeze.
+    monkeypatch.setattr(I, "_iter_sessions",
+                        lambda since=None, exclude=None: iter([
+                            ("s1", I.Path("/x/s1.jsonl"), "-Users-rbr-proj"),
+                            ("s2", I.Path("/x/s2.jsonl"), "-Users-rbr-proj"),
+                        ]))
+    monkeypatch.setattr(I, "_parse_jsonl", lambda path: [])  # all skipped_empty; no DB touch
+    monkeypatch.setattr(I, "_load_ledger", lambda: {"existing": "id"})  # not first run
+    I.ingest(dry_run=True)
+    out = capsys.readouterr().out
+    assert "2 sessions" in out
+    assert "may take a few minutes" in out
+
+
+# ── B3: first-run nudge about the 7-day default window ────────────────────────
+
+def test_first_run_true_when_ledger_empty(monkeypatch):
+    monkeypatch.setattr(I, "_load_ledger", lambda: {})
+    assert S._is_first_run() is True
+
+
+def test_first_run_false_when_ledger_has_entries(monkeypatch):
+    monkeypatch.setattr(I, "_load_ledger", lambda: {"h1": "id1"})
+    assert S._is_first_run() is False
+
+
+def test_nudge_prints_on_first_run_default_window(capsys, monkeypatch):
+    monkeypatch.setattr(S, "_is_first_run", lambda: True)
+    monkeypatch.setattr("fidelis.ingest_claude_sessions.ingest",
+                        lambda **kw: dict(scanned=0, stored=0, skipped_dedup=0,
+                                          skipped_empty=0, errors=0))
+    S.cmd_ingest(_IngestArgs(all=False, since=None, dry_run=True))
+    out = capsys.readouterr().out
+    assert "--all" in out and "full history" in out
+
+
+def test_nudge_suppressed_when_not_first_run(capsys, monkeypatch):
+    monkeypatch.setattr(S, "_is_first_run", lambda: False)
+    monkeypatch.setattr("fidelis.ingest_claude_sessions.ingest",
+                        lambda **kw: dict(scanned=0, stored=0, skipped_dedup=0,
+                                          skipped_empty=0, errors=0))
+    S.cmd_ingest(_IngestArgs(all=False, since=None, dry_run=True))
+    out = capsys.readouterr().out
+    assert "full history" not in out
+
+
+def test_nudge_suppressed_when_all_flag(capsys, monkeypatch):
+    # --all is not the default window, so the nudge must not fire even on first run.
+    monkeypatch.setattr(S, "_is_first_run", lambda: True)
+    monkeypatch.setattr("fidelis.ingest_claude_sessions.ingest",
+                        lambda **kw: dict(scanned=0, stored=0, skipped_dedup=0,
+                                          skipped_empty=0, errors=0))
+    S.cmd_ingest(_IngestArgs(all=True, since=None, dry_run=True))
+    out = capsys.readouterr().out
+    assert "full history" not in out

--- a/tests/test_sessions_mvp_a.py
+++ b/tests/test_sessions_mvp_a.py
@@ -25,6 +25,156 @@ def test_denylist_env_parsing(monkeypatch):
     assert I._load_exclude() == ["a", "b", "c"]
 
 
+# ── allow-list + ingest MODE (opt-in / opt-out privacy posture) ───────────────
+
+def test_allowlist_includes_matching_project():
+    assert I._included("-Users-rbr-hermes-rubric", ["hermes"]) is True
+
+def test_allowlist_excludes_nonmatching_project():
+    assert I._included("-Users-rbr-lpci", ["hermes"]) is False
+
+def test_allowlist_empty_includes_nothing():
+    # opt-in mirror of the deny-list: empty/None matches nothing → indexes nothing
+    assert I._included("-Users-rbr-anything", []) is False
+    assert I._included("-Users-rbr-anything", None) is False
+
+def test_allowlist_env_parsing(monkeypatch):
+    monkeypatch.setenv("FIDELIS_SESSIONS_INCLUDE", " a , b ,, c ")
+    assert I._load_include() == ["a", "b", "c"]
+
+
+def test_mode_defaults_to_opt_out(monkeypatch, tmp_path):
+    monkeypatch.delenv("FIDELIS_SESSIONS_MODE", raising=False)
+    monkeypatch.setattr(I.Path, "home", staticmethod(lambda: tmp_path))  # no config.json
+    assert I._load_mode() == "opt-out"
+
+def test_mode_read_from_env(monkeypatch):
+    monkeypatch.setenv("FIDELIS_SESSIONS_MODE", "opt-in")
+    assert I._load_mode() == "opt-in"
+
+def test_mode_env_invalid_falls_back_to_opt_out(monkeypatch, tmp_path):
+    monkeypatch.setenv("FIDELIS_SESSIONS_MODE", "garbage")
+    monkeypatch.setattr(I.Path, "home", staticmethod(lambda: tmp_path))
+    assert I._load_mode() == "opt-out"
+
+def test_mode_read_from_config_json(monkeypatch, tmp_path):
+    monkeypatch.delenv("FIDELIS_SESSIONS_MODE", raising=False)
+    cfg_dir = tmp_path / ".cogito"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(I.json.dumps({"sessions_mode": "opt-in"}))
+    monkeypatch.setattr(I.Path, "home", staticmethod(lambda: tmp_path))
+    assert I._load_mode() == "opt-in"
+
+def test_mode_env_overrides_config(monkeypatch, tmp_path):
+    # config says opt-in, env says opt-out → env wins (matches config.py semantics)
+    cfg_dir = tmp_path / ".cogito"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(I.json.dumps({"sessions_mode": "opt-in"}))
+    monkeypatch.setattr(I.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("FIDELIS_SESSIONS_MODE", "opt-out")
+    assert I._load_mode() == "opt-out"
+
+def test_mode_config_malformed_falls_back_to_opt_out(monkeypatch, tmp_path):
+    monkeypatch.delenv("FIDELIS_SESSIONS_MODE", raising=False)
+    cfg_dir = tmp_path / ".cogito"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text("{ not valid json ")
+    monkeypatch.setattr(I.Path, "home", staticmethod(lambda: tmp_path))
+    assert I._load_mode() == "opt-out"
+
+
+# ── _iter_sessions honours the mode (allow-list vs deny-list selection) ────────
+
+def _fake_projects(tmp_path, names):
+    """Build a fake ~/.claude/projects tree with one empty *.jsonl per project."""
+    root = tmp_path / "projects"
+    root.mkdir()
+    for n in names:
+        d = root / n
+        d.mkdir()
+        (d / "sess.jsonl").write_text("")  # presence is enough; we don't parse here
+    return root
+
+
+def test_iter_opt_out_indexes_all_but_excluded(monkeypatch, tmp_path):
+    root = _fake_projects(tmp_path, ["-Users-rbr-hermes", "-Users-rbr-client-secret", "-Users-rbr-lpci"])
+    monkeypatch.setattr(I, "CLAUDE_PROJECTS", root)
+    seen = {p for _, _, p in I._iter_sessions(mode="opt-out", exclude=["client-secret"])}
+    assert seen == {"-Users-rbr-hermes", "-Users-rbr-lpci"}  # excluded one dropped
+
+def test_iter_opt_in_indexes_only_included(monkeypatch, tmp_path):
+    root = _fake_projects(tmp_path, ["-Users-rbr-hermes", "-Users-rbr-client-secret", "-Users-rbr-lpci"])
+    monkeypatch.setattr(I, "CLAUDE_PROJECTS", root)
+    seen = {p for _, _, p in I._iter_sessions(mode="opt-in", include=["hermes"])}
+    assert seen == {"-Users-rbr-hermes"}  # ONLY the allow-listed project
+
+def test_iter_opt_in_empty_include_yields_nothing(monkeypatch, tmp_path):
+    root = _fake_projects(tmp_path, ["-Users-rbr-hermes", "-Users-rbr-lpci"])
+    monkeypatch.setattr(I, "CLAUDE_PROJECTS", root)
+    seen = list(I._iter_sessions(mode="opt-in", include=[]))
+    assert seen == []  # opt-in + empty allow-list = index nothing
+
+
+# ── ingest() wiring: opt-out preserves behaviour, opt-in onboards ─────────────
+
+def test_ingest_opt_out_preserves_existing_behaviour(capsys, monkeypatch):
+    # opt-out is the default: existing deny-list path is untouched. Two candidates
+    # flow through (then skipped_empty since _parse_jsonl returns []), proving the
+    # iterator was actually consumed — i.e. opt-out indexes-except-excluded intact.
+    monkeypatch.setattr(I, "_load_mode", lambda: "opt-out")
+    monkeypatch.setattr(I, "_iter_sessions",
+                        lambda since=None, exclude=None, mode="opt-out", include=None: iter([
+                            ("s1", I.Path("/x/s1.jsonl"), "-Users-rbr-proj"),
+                            ("s2", I.Path("/x/s2.jsonl"), "-Users-rbr-proj"),
+                        ]))
+    monkeypatch.setattr(I, "_parse_jsonl", lambda path: [])
+    monkeypatch.setattr(I, "_load_ledger", lambda: {"existing": "id"})
+    stats = I.ingest(dry_run=True)
+    out = capsys.readouterr().out
+    assert "2 sessions" in out
+    assert stats["scanned"] == 2
+
+def test_ingest_opt_in_with_include_indexes_only_matching(capsys, monkeypatch):
+    # opt-in + non-empty allow-list: iterator must be called with mode/include and
+    # only yield the matching project. We assert the passthrough by inspecting args.
+    captured = {}
+    def fake_iter(since=None, exclude=None, mode="opt-out", include=None):
+        captured["mode"] = mode
+        captured["include"] = include
+        return iter([("s1", I.Path("/x/s1.jsonl"), "-Users-rbr-hermes")])
+    monkeypatch.setattr(I, "_iter_sessions", fake_iter)
+    monkeypatch.setattr(I, "_parse_jsonl", lambda path: [])
+    monkeypatch.setattr(I, "_load_ledger", lambda: {"existing": "id"})
+    stats = I.ingest(dry_run=True, mode="opt-in", include=["hermes"])
+    out = capsys.readouterr().out
+    assert captured == {"mode": "opt-in", "include": ["hermes"]}
+    assert "1 sessions" in out
+    assert "no projects included yet" not in out
+    assert stats["scanned"] == 1
+
+def test_ingest_opt_in_empty_include_prints_onboarding_and_indexes_nothing(capsys, monkeypatch):
+    # Setup-sensitive: empty allow-list in opt-in mode must NOT silently no-op.
+    # It prints the onboarding message and indexes nothing, without walking the tree.
+    def boom(*a, **k):
+        raise AssertionError("_iter_sessions must not run when include is empty")
+    monkeypatch.setattr(I, "_iter_sessions", boom)
+    stats = I.ingest(dry_run=True, mode="opt-in", include=[])
+    out = capsys.readouterr().out
+    assert "opt-in mode: no projects included yet" in out
+    assert "FIDELIS_SESSIONS_INCLUDE" in out
+    assert stats == {"scanned": 0, "skipped_dedup": 0, "skipped_empty": 0, "stored": 0, "errors": 0}
+
+def test_ingest_reads_mode_from_env_when_not_passed(capsys, monkeypatch):
+    # ingest() with no mode arg falls back to _load_mode() (env/config). Set env to
+    # opt-in with empty include → onboarding path, proving the env was honoured.
+    monkeypatch.setenv("FIDELIS_SESSIONS_MODE", "opt-in")
+    monkeypatch.delenv("FIDELIS_SESSIONS_INCLUDE", raising=False)
+    stats = I.ingest(dry_run=True)
+    out = capsys.readouterr().out
+    assert "opt-in mode: no projects included yet" in out
+    assert stats["stored"] == 0
+
+
 # ── purge target collection (the locked contract) ────────────────────────────
 
 def _meta(end_ts, h):
@@ -107,7 +257,7 @@ def test_ingest_prints_candidate_count_up_front(capsys, monkeypatch):
     # B2: before the loop, ingest() must announce how many sessions it will index
     # so a long run doesn't read as a freeze.
     monkeypatch.setattr(I, "_iter_sessions",
-                        lambda since=None, exclude=None: iter([
+                        lambda since=None, exclude=None, mode="opt-out", include=None: iter([
                             ("s1", I.Path("/x/s1.jsonl"), "-Users-rbr-proj"),
                             ("s2", I.Path("/x/s2.jsonl"), "-Users-rbr-proj"),
                         ]))

--- a/tests/test_sessions_mvp_a.py
+++ b/tests/test_sessions_mvp_a.py
@@ -55,6 +55,19 @@ def test_collect_before_none_matches_nothing_when_future():
     tids, _ = S._collect_purge_targets(metas, ["c2"], "before", "2026-04-30")
     assert tids == []
 
+def test_purge_span_reflects_matched_set_not_whole_corpus():
+    # honesty/polish: the summary span must describe what WILL be deleted,
+    # not the entire corpus. Regression guard for the 2026-06-06 fix.
+    metas = [_meta("2026-04-01T00:00:00Z", "h1"),   # matched (before 04-30)
+             _meta("2026-05-30T00:00:00Z", "h2")]   # NOT matched
+    ids = ["c1", "c2"]
+    target_ids, _ = S._collect_purge_targets(metas, ids, "before", "2026-04-30")
+    target_set = set(target_ids)
+    ends = sorted(m.get("end_ts", "") for cid, m in zip(ids, metas)
+                  if cid in target_set and m.get("end_ts"))
+    span = f"{ends[0][:10]}..{ends[-1][:10]}" if ends else "unknown"
+    assert span == "2026-04-01..2026-04-01"   # NOT ..2026-05-30
+
 
 # ── honesty invariants (these protect the brand) ─────────────────────────────
 

--- a/tests/test_sessions_mvp_a.py
+++ b/tests/test_sessions_mvp_a.py
@@ -1,0 +1,81 @@
+"""Gate tests for MVP-A `fidelis sessions`. Pure-logic — no ChromaDB/Ollama needed.
+These are the acceptance criteria AS TESTS (the contact-gate): the build is not
+done until these pass.
+"""
+import json
+import importlib
+
+from fidelis import sessions_cmd as S
+from fidelis import ingest_claude_sessions as I
+
+
+# ── deny-list (privacy lever) ────────────────────────────────────────────────
+
+def test_denylist_excludes_matching_project():
+    assert I._excluded("-Users-rbr-client-secret", ["client-secret"]) is True
+
+def test_denylist_keeps_nonmatching_project():
+    assert I._excluded("-Users-rbr-lpci", ["client-secret"]) is False
+
+def test_denylist_empty_excludes_nothing():
+    assert I._excluded("-Users-rbr-anything", []) is False
+    assert I._excluded("-Users-rbr-anything", None) is False
+
+def test_denylist_env_parsing(monkeypatch):
+    monkeypatch.setenv("FIDELIS_SESSIONS_EXCLUDE", " a , b ,, c ")
+    assert I._load_exclude() == ["a", "b", "c"]
+
+
+# ── purge target collection (the locked contract) ────────────────────────────
+
+def _meta(end_ts, h):
+    return {"end_ts": end_ts, "ingest_hash": h, "mem_type": "session"}
+
+def test_iso_before():
+    assert S._iso_before("2026-04-20T10:00:00Z", "2026-04-30") is True
+    assert S._iso_before("2026-05-30T10:00:00Z", "2026-04-30") is False
+    assert S._iso_before("", "2026-04-30") is False  # missing ts never matches
+
+def test_collect_all_takes_everything():
+    metas = [_meta("2026-04-01T00:00:00Z", "h1"), _meta("2026-05-01T00:00:00Z", "h2")]
+    ids = ["c1", "c2"]
+    tids, ths = S._collect_purge_targets(metas, ids, "all", None)
+    assert tids == ["c1", "c2"]
+    assert ths == ["h1", "h2"]  # hashes collected for ledger cleanup (spec step 3)
+
+def test_collect_before_filters_by_date():
+    metas = [_meta("2026-04-01T00:00:00Z", "h1"), _meta("2026-05-01T00:00:00Z", "h2")]
+    ids = ["c1", "c2"]
+    tids, ths = S._collect_purge_targets(metas, ids, "before", "2026-04-30")
+    assert tids == ["c1"]          # only the April session
+    assert ths == ["h1"]
+
+def test_collect_before_none_matches_nothing_when_future():
+    metas = [_meta("2026-05-01T00:00:00Z", "h2")]
+    tids, _ = S._collect_purge_targets(metas, ["c2"], "before", "2026-04-30")
+    assert tids == []
+
+
+# ── honesty invariants (these protect the brand) ─────────────────────────────
+
+def test_backup_boundary_present_in_messages():
+    # deletion claims must always carry the source/backup-not-touched boundary
+    assert "NOT touched" in S.BACKUP_BOUNDARY
+    assert "~/.claude/projects" in S.BACKUP_BOUNDARY
+    assert "~/Backups/claude-sessions" in S.BACKUP_BOUNDARY
+
+def test_no_benchmark_numbers_in_product_strings():
+    # Honesty rule: benchmark numbers must never appear in USER-FACING strings.
+    # Check the module-level constants + any string literal printed to users,
+    # not source comments/docstrings (those legitimately discuss the rule).
+    forbidden = ["93.4", "96.4"]
+    for const in (S.BACKUP_BOUNDARY, S.PRIVACY_NOTICE):
+        for f in forbidden:
+            assert f not in const, f"benchmark number {f} leaked into product string"
+    # the sanctioned honest label appears in the search-empty product string
+    src = open(importlib.import_module("fidelis.sessions_cmd").__file__).read()
+    assert "best on multi-turn queries" in src
+
+def test_privacy_notice_mentions_local_and_purge():
+    assert "~/.cogito" in S.PRIVACY_NOTICE
+    assert "purge" in S.PRIVACY_NOTICE

--- a/tests/test_sessions_mvp_a.py
+++ b/tests/test_sessions_mvp_a.py
@@ -2,7 +2,6 @@
 These are the acceptance criteria AS TESTS (the contact-gate): the build is not
 done until these pass.
 """
-import json
 import importlib
 
 from fidelis import sessions_cmd as S


### PR DESCRIPTION
## fidelis sessions — searchable, purge-able Claude Code session memory

Claude Code deletes sessions after 30 days. fidelis can now keep them locally and make them searchable.

### Commands
- `fidelis sessions search <query>` — find past conversations (best on multi-turn queries)
- `fidelis sessions list` / `stats` — browse + summarize indexed sessions
- `fidelis sessions ingest` — index sessions (default: last 7 days; `--all` for full history)
- `fidelis sessions purge` — delete from the search index (NEVER touches ~/.claude/projects or backups)

### Privacy posture (user-chosen)
- `FIDELIS_SESSIONS_MODE=opt-in|opt-out` (default opt-out). opt-in indexes only `FIDELIS_SESSIONS_INCLUDE` projects; opt-out indexes all except `FIDELIS_SESSIONS_EXCLUDE`.
- Stored locally in ~/.cogito (chmod 700), not application-encrypted; see SECURITY.md.

### Verification
- 135 tests pass; ruff clean; fresh `pip install` exposes the command; purge is index-only and audited.
- Built behind a CLEAN-bar review + simulated user-interview pass.
