### PR TITLE
chore(bench): read DashScope key from env var instead of inline

### DIFF
--- a/bench/qwen_native_arena.py
+++ b/bench/qwen_native_arena.py
@@ -1,3 +1,4 @@
+import os
 """
 Qwen-Native Scaffold Arena — test 15 new scaffolds on qwen-turbo.
 
@@ -24,7 +25,7 @@ from collections import defaultdict
 # ---------------------------------------------------------------------------
 QWEN_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
 QWEN_MODEL = "qwen-turbo"
-QWEN_API_KEY = "sk-723d1e2f969c456ba3ffe315c0673e9b"
+QWEN_API_KEY = os.environ.get("DASHSCOPE_API_KEY", "")
 
 DATA_PATH = Path.home() / "Documents/projects/LongMemEval/data/longmemeval_s_cleaned.json"
 PER_QUESTION_PATH = Path(__file__).parent / "runs/runC-guard/per_question.json"

--- a/bench/run_ablations.py
+++ b/bench/run_ablations.py
@@ -110,7 +110,7 @@ def run_ablation(ablation: dict, resume: bool, data_dir: str | None) -> dict | N
     env = os.environ.copy()
     if not env.get("DASHSCOPE_API_KEY"):
         # Try hardcoded key from task spec as fallback
-        env["DASHSCOPE_API_KEY"] = "sk-723d1e2f969c456ba3ffe315c0673e9b"
+        env["DASHSCOPE_API_KEY"] = os.environ.get("DASHSCOPE_API_KEY", "")
 
     t_start = time.time()
     try:

--- a/bench/scaffold_transfer_validation.py
+++ b/bench/scaffold_transfer_validation.py
@@ -23,7 +23,7 @@ from datetime import datetime
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
-DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY", "sk-723d1e2f969c456ba3ffe315c0673e9b")
+DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY", os.environ.get("DASHSCOPE_API_KEY", ""))
 QWEN_MODEL = "qwen-turbo"
 QWEN_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
 


### PR DESCRIPTION
Routine config hygiene: the benchmark scripts now read `DASHSCOPE_API_KEY` from the environment instead of an inline literal (matches the pattern already documented in the README). No behavior change. Docs/bench only.