### PR TITLE
docs: correct Fidelis install and public evidence claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI
 
-# Hermetic CI for v0.0.9: runs on fresh Ubuntu and macOS runners. Proves the
+# Hermetic CI for v0.0.91: runs on fresh Ubuntu and macOS runners. Proves the
 # fidelis package installs cleanly from source on a box that has never seen it
-# before — the equivalent of a beta tester running `pip install`. Tests that
-# require a live Ollama or LLM endpoint are excluded by directory; the rest
-# (~470) must pass on every commit.
+# before — the equivalent of a beta tester installing the tagged source. Tests
+# that require a live Ollama or LLM endpoint are excluded by directory; the
+# rest (~470) must pass on every commit.
 #
 # What this catches:
 #   - missing dependencies (e.g. the `ollama` python lib that crashed our

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# Unreleased
+
+- Correct every current install surface to use tagged GitHub source; the PyPI
+  project named `fidelis` is unrelated to Hermes Labs Fidelis.
+- Align public package status with v0.0.91 and remove a dead benchmark link.
+- Narrow local-data and compliance wording to the demonstrated boundary.
+- Document that direct server launches need the telemetry environment settings
+  which `fidelis init` installs automatically.
+- Remove cross-project proof language from current Fidelis presentation.
+- Add a regression test for the public installation contract.
+
 # fidelis era
 ## v0.0.91 — 2026-06-18 (public release)
 - Public open-source release on GitHub + Zenodo DOI.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **73.0% end-to-end QA on LongMemEval-S. 83.2% R@1 retrieval. $0/query. No LLM in the default retrieval path.**
 
-Stop re-explaining context to your agent. fidelis returns your original notes verbatim, local-first, fast, about 60 seconds to install. Your agent already calls an LLM to think; it should not need another one just to remember. Designed for developers. Default zero-LLM retrieval path runs fully local with no outbound network calls, which simplifies SOC2 / HIPAA scoping for the memory layer.
+Stop re-explaining context to your agent. fidelis returns your original notes verbatim, local-first, fast, about 60 seconds to install. Your agent already calls an LLM to think; it should not need another one just to remember. Designed for developers. The default zero-LLM retrieval path does not send memory content to an LLM. The documented `fidelis init` service configuration also disables mem0 and Chroma telemetry. That can reduce third-party data exposure, but deployments still own their security and compliance assessment.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Status: pre-release](https://img.shields.io/badge/status-pre--release-orange)](#known-limitations)
@@ -41,17 +41,24 @@ What fidelis is:
 brew install ollama && ollama serve &
 ollama pull nomic-embed-text
 
-# 1. install + run
-pip install fidelis
+# 1. install the v0.0.91 GitHub source release (not the unrelated PyPI project)
+git clone --branch v0.0.91 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
+cd fidelis
+python3 -m pip install .
 fidelis init                  # background service (launchd / systemd)
 fidelis watch ~/notes         # auto-ingests markdown
 fidelis mcp install           # wires Claude Code
 # Restart Claude Code. Memory is on.
 ```
 
+> **Package-name warning:** `fidelis` on PyPI belongs to the unrelated
+> [NGdust/fidelis](https://github.com/NGdust/fidelis) tabular-data project.
+> Hermes Labs Fidelis is not published on PyPI. Install this project only from
+> its tagged GitHub source as shown above.
+
 Linux users swap `brew install ollama` for the equivalent install from [ollama.com](https://ollama.com). [See Requirements](#requirements).
 
-v0.0.9 - pre-release.
+v0.0.91 - GitHub source release; not published on PyPI.
 
 ## What you notice immediately
 
@@ -109,7 +116,7 @@ The MCP `fidelis_recall` tool fires before Claude composes its answer. Claude se
 Three concrete reasons teams pick fidelis over hosted memory:
 
 - **Cost reduction.** Stop paying for redundant context-window tokens on every turn. Memory lives on disk; the agent pulls only what's relevant per query. At a few thousand calls/day the math against per-query memory APIs adds up fast.
-- **Security & compliance.** Zero data egress in the default zero-LLM path simplifies SOC2 / HIPAA scoping for the agent-memory layer - your notes never leave the box, so the memory store falls outside any third-party data-processor agreement.
+- **Local data boundary.** The default zero-LLM path keeps notes and retrieval on the local machine, reducing third-party processor exposure. This architecture does not by itself confer SOC 2 or HIPAA compliance.
 - **Team context.** Agents that remember historical decisions, naming conventions, failed migrations, and the *qualifiers* on those decisions. The non-configurable detail you wrote down two months ago surfaces when relevant, in the founder's voice, not paraphrased.
 
 ## How it fits
@@ -130,7 +137,7 @@ LongMemEval-S, 470 questions, public benchmark.
 
 For context: published Mem0 results on LongMemEval-S are in the ~66–70% end-to-end QA range; Zep is 71.2%; Supermemory is 81.6%; full GPT-4o on raw context (no memory system) is 60.2%. fidelis reaches 73.0% with no LLM in the default retrieval path.
 
-Raw evidence: [`bench/runs/zeroLLM-full-20260424/aggregate.json`](bench/runs/zeroLLM-full-20260424/aggregate.json) · [`experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json`](experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json)
+Raw evidence: [`experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json`](experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json)
 
 The QA tier wraps your existing LLM with a 140–180-token system prompt - the Fidelis Scaffold. See [`docs/scaffold.md`](docs/scaffold.md).
 
@@ -200,10 +207,15 @@ After `fidelis init`:
 
 To stop: `fidelis init --uninstall`. To wipe: `rm -rf ~/.cogito ~/.fidelis`.
 
-## Known limitations (v0.0.9 honest list)
+## Known limitations (v0.0.91)
 
 - **Pre-release.** Python function names and CLI commands may change. Pin the version if you build on it.
 - **Best on macOS Sequoia / Ubuntu 24.04 LTS.** Other OSes likely work but aren't gate-tested.
+- **Direct server launches need explicit telemetry settings.** `fidelis init`
+  installs a service with mem0 and Chroma telemetry disabled. If you run
+  `fidelis-server` directly, set `MEM0_TELEMETRY=False`,
+  `ANONYMIZED_TELEMETRY=False`, and `CHROMA_TELEMETRY_DISABLED=True` before
+  startup to get the same boundary.
 - **Temporal-reasoning and preference questions are the weakest qtypes** in the QA scaffold (TR ~58%, Pref ~37% on the full eval). Single-session and knowledge-update qtypes are strong (95–100%).
 - **The optional LLM tier ("flagship" mode) currently escalates ~80% of queries instead of the intended ~10%** - an 8× cost miss we're transparent about. The default zero-LLM tier is unaffected.
 - **qwen3.5:9b in thinking mode does not reliably follow the literal hedge instruction** in the Fidelis Scaffold. Use Claude, an OpenAI-format API, or non-thinking-mode local models for reliable hedging.
@@ -234,11 +246,11 @@ MIT. Built by Hermes Labs (Roli Bosch). Issues + PRs welcome.
 
 ## About Hermes Labs
 
-Hermes Labs is building reliability infrastructure for autonomous AI agents - memory, evaluation, observability, and containment. Founded 2025 by Rolando (Roli) Bosch, solo founder, AI-amplified ("cyborg engineering"). Based in the San Francisco Bay Area.
-
-The technical thesis: language sets the capability and intelligence; the model is the ceiling, not the source. Reliability is a question of linguistic infrastructure, not model tuning. Formalized as LPCI (Linguistically Persistent Cognitive Interface) - transfer entropy ≈ 0 in embedding-space proxy, Markov property holds, the substrate is linguistic. The engineering follow-on: when language is the substrate, the engineering is interpretive - recovering meaning across the boundaries between model and user, session and session, training and runtime.
-
-Public technical receipts. The first public open-source release is [fidelis](https://github.com/hermes-labs-ai/fidelis) - zero-LLM agent memory with integer-pointer fidelity. 73.0% end-to-end QA on LongMemEval-S, Wilson 95% CI [68.7%, 77.0%], at $0 per query, fully local. Other Hermes Labs OSS is listed at [github.com/hermes-labs-ai](https://github.com/hermes-labs-ai). Published research at [zenodo.org](https://zenodo.org). The OSS surface is the proof; the commercial work is deployment engagements.
+Hermes Labs develops open-source reliability, evaluation, memory, and
+containment tools for AI agents. Fidelis is its local-first memory project.
+Other public software is listed at
+[github.com/hermes-labs-ai](https://github.com/hermes-labs-ai), with research
+artifacts published separately on [Zenodo](https://zenodo.org).
 
 For enterprise deployments and AI-reliability engagements: [roli@hermes-labs.ai](mailto:roli@hermes-labs.ai) · [hermes-labs.ai](https://hermes-labs.ai)
 
@@ -248,7 +260,7 @@ Founder: Rolando (Roli) Bosch.
 Site: [hermes-labs.ai](https://hermes-labs.ai)
 Citation: Bosch, R. (2026). Hermes Labs: AI reliability infrastructure for autonomous agents. https://hermes-labs.ai
 
-Quantitative sources for claims above:
-- fidelis 73.0% / Wilson 95% CI [68.7%, 77.0%]: see fidelis/README.md "End-to-end QA accuracy" + experiments/zeroLLM-FLAGSHIP-evidence/, 470 questions, eval date 2026-04-24
-- LPCI thesis (TE ≈ 0 embedding-space proxy): langquant repo, commit dd918cc (2026-03-28) "LPCI PROVED" + lpci_rigorous.py:507-571
-- 24-failure taxonomy: hermes-rubric/calibration/failure-mode-taxonomy.md
+Quantitative source for the Fidelis claims above: the 470-question
+LongMemEval-S aggregate and Wilson interval in
+[`experiments/zeroLLM-FLAGSHIP-evidence/`](experiments/zeroLLM-FLAGSHIP-evidence/),
+evaluated 2026-04-24.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ LongMemEval-S, 470 questions, public benchmark.
 
 For context: published Mem0 results on LongMemEval-S are in the ~66–70% end-to-end QA range; Zep is 71.2%; Supermemory is 81.6%; full GPT-4o on raw context (no memory system) is 60.2%. fidelis reaches 73.0% with no LLM in the default retrieval path.
 
-Raw evidence: [`experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json`](experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json)
+Raw evidence: [retrieval aggregate](bench/runs/runP-v35/aggregate.json) ·
+[end-to-end QA summary](experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json)
 
 The QA tier wraps your existing LLM with a 140–180-token system prompt - the Fidelis Scaffold. See [`docs/scaffold.md`](docs/scaffold.md).
 

--- a/agents.md
+++ b/agents.md
@@ -203,5 +203,5 @@ Env-var aliases of note (set without touching config files):
 ## Source
 
 https://github.com/hermes-labs-ai/fidelis
-PyPI: https://pypi.org/project/fidelis/
+Distribution: tagged GitHub source only. The PyPI project named `fidelis` is unrelated.
 Part of the Hermes Labs suite: https://hermes-labs.ai

--- a/docs/claude-code-memory-demo.md
+++ b/docs/claude-code-memory-demo.md
@@ -82,7 +82,7 @@ Query: "what did we discuss about LPCI proof last week?"
 **`cogito_recall_both`** — atomic facts + session history side-by-side
 ```
 === ATOMIC (facts) ===
-  [1] LPCI PROVED 2026-03-28: stateless LLM holds state via language scaffold, TE≈0
+  [1] LPCI 2026-03-28: one 20-turn A/B run tested language-scaffold state; single observation, not proof
   ...
 
 === SESSIONS (Claude Code history) ===

--- a/docs/full-reference.md
+++ b/docs/full-reference.md
@@ -233,7 +233,7 @@ Measured 2026-04-24. Zero-LLM retrieval pipeline (BM25 + turn-level + prefixes +
 
 Per-qtype R@1: single-session-assistant 100%, knowledge-update 95.8%, single-session-user 95.3%, multi-session 83.5%, single-session-preference 66.7%, temporal-reasoning 66.1%.
 
-Raw aggregate: [`../experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json`](../experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json).
+Raw retrieval aggregate: [`../bench/runs/runP-v35/aggregate.json`](../bench/runs/runP-v35/aggregate.json).
 
 ### Secondary: internal `/recall` atomic-fact eval
 

--- a/docs/full-reference.md
+++ b/docs/full-reference.md
@@ -1,15 +1,16 @@
 # fidelis
 
-> **v0.1.0 (2026-04-27).** Agent memory that's on by default. One command
-> starts the service, one command auto-ingests your notes, one command wires
-> Claude Code. 73% QA on LongMemEval-S, $0/q via Claude subscription, fully
-> local retrieval. **Validated on Claude + OpenAI-format APIs at 100/100
-> hedge + answer compliance. 383 tests passing.**
+> **Package release v0.0.91 (2026-06-18).** The separately versioned Fidelis
+> Scaffold protocol remains v0.1.0 in the API and examples below. Hermes Labs
+> Fidelis is distributed from tagged GitHub source and is not the unrelated
+> PyPI project named `fidelis`.
 
 ## 60-second quickstart
 
 ```bash
-pip install fidelis
+git clone --branch v0.0.91 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
+cd fidelis
+python3 -m pip install .
 fidelis init                  # installs + starts the service (launchd/systemd)
 fidelis watch ~/notes         # auto-ingests markdown/text, polls for new files
 fidelis mcp install           # wires Claude Code MCP integration
@@ -102,8 +103,7 @@ Full 470-question evaluation in progress; smoke evidence + machine-readable summ
 
 A separate `/recall` atomic path is purpose-built for short-fact lookup (not session retrieval); it scores 85% R@1 combined with the snapshot layer on a 31-case internal atomic-fact eval. This is a secondary surface; the headline retrieval number above (83.2% R@1 on the full 470-question LongMemEval-S) is the authoritative session-retrieval measurement.
 
-[![PyPI version](https://img.shields.io/pypi/v/fidelis)](https://pypi.org/project/fidelis/)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://pypi.org/project/fidelis/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Made by Hermes Labs](https://img.shields.io/badge/made%20by-Hermes%20Labs-purple)](https://hermes-labs.ai)
 
@@ -233,7 +233,7 @@ Measured 2026-04-24. Zero-LLM retrieval pipeline (BM25 + turn-level + prefixes +
 
 Per-qtype R@1: single-session-assistant 100%, knowledge-update 95.8%, single-session-user 95.3%, multi-session 83.5%, single-session-preference 66.7%, temporal-reasoning 66.1%.
 
-Raw aggregate: [`bench/runs/zeroLLM-full-20260424/aggregate.json`](bench/runs/zeroLLM-full-20260424/aggregate.json).
+Raw aggregate: [`../experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json`](../experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json).
 
 ### Secondary: internal `/recall` atomic-fact eval
 
@@ -258,7 +258,9 @@ Key results:
 **1. Install**
 
 ```bash
-pip install fidelis
+git clone --branch v0.0.91 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
+cd fidelis
+python3 -m pip install .
 ```
 
 **2. Pull Ollama models**
@@ -412,7 +414,7 @@ Query
 
 ```bash
 # Optional dependency for best BM25 fusion (zero deps fallback if absent)
-pip install fidelis[hybrid]
+python3 -m pip install '.[hybrid]'
 
 # Opt-in: set a filter endpoint (any OpenAI-compatible API)
 export COGITO_FILTER_ENDPOINT=https://dashscope-intl.aliyuncs.com/compatible-mode/v1

--- a/llms.txt
+++ b/llms.txt
@@ -158,17 +158,15 @@ All by Hermes Labs (https://hermes-labs.ai).
 
 ## Install
 
-pip install fidelis
+git clone --branch v0.0.91 --depth 1 https://github.com/hermes-labs-ai/fidelis.git && cd fidelis && python3 -m pip install .
 Python 3.10+. MIT license.
 Repo: https://github.com/hermes-labs-ai/fidelis
-PyPI: https://pypi.org/project/fidelis/
+Package warning: NOT published on PyPI. The PyPI project named "fidelis" is unrelated (NGdust/fidelis).
 Author: Hermes Labs (roli@hermes-labs.ai)
 
 ## About Hermes Labs
 
-Hermes Labs is building the reliability stack for the agent era. Memory, evaluation, observability, containment — the infrastructure layer that makes autonomous AI agents production-grade. Founded 2025 by Rolando (Roli) Bosch, solo founder, AI-amplified ("cyborg engineering"). Based in the San Francisco Bay Area.
-
-The technical thesis: language sets the capability and intelligence; the model is the ceiling, not the source. Reliability is a question of linguistic infrastructure, not model tuning. Formalized as LPCI (Linguistically Persistent Cognitive Interface) — transfer entropy ≈ 0 in embedding-space proxy, Markov property holds, the substrate is linguistic. The engineering follow-on: when language is the substrate, the engineering is interpretive — recovering meaning across the boundaries between model and user, session and session, training and runtime.
+Hermes Labs develops open-source reliability, evaluation, memory, and containment tools for AI agents. Fidelis is its local-first memory project. Other public software: https://github.com/hermes-labs-ai
 
 Public technical receipts. The flagship open-source release is fidelis — zero-LLM agent memory with integer-pointer fidelity. 73.0% end-to-end QA on LongMemEval-S, Wilson 95% CI [68.7%, 77.0%], at $0 per query, fully local. Companion open-source: lintlang, hermes-rubric, hermes-blind, hermes-prime, hermes-ctl. Published research at zenodo.org and the Hermes Labs paper line. The OSS surface is the proof; the commercial work is enterprise deployments.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   # mem0's ollama embedder lazy-imports `ollama`. Without it on PYTHONPATH,
   # mem0 hits an interactive input() prompt at boot, which crashes a
   # non-tty server context (launchd / systemd / MCP) with EOFError. Bundling
-  # the client makes `pip install fidelis` non-interactive end-to-end.
+  # the client makes a source install non-interactive end-to-end.
   "ollama>=0.4.0",
 ]
 

--- a/src/fidelis/init_cmd.py
+++ b/src/fidelis/init_cmd.py
@@ -116,8 +116,8 @@ def _server_bin() -> str:
         return str(candidate)
     raise RuntimeError(
         "fidelis-server entry point not found on PATH. "
-        "Did you `pip install fidelis`? If running from source, "
-        "`pip install -e .` to register the console script."
+        "Reinstall Hermes Labs Fidelis from its tagged GitHub source; "
+        "see the README installation instructions."
     )
 
 

--- a/src/fidelis/mcp_cmd.py
+++ b/src/fidelis/mcp_cmd.py
@@ -39,7 +39,8 @@ def cmd_mcp_install(args) -> int:
     if not MCP_SERVER_FILE.exists():
         print(
             f"error: bundled MCP server not found at {MCP_SERVER_FILE}\n"
-            f"  this fidelis install appears incomplete; reinstall with `pip install fidelis`",
+            "  this install appears incomplete; reinstall Hermes Labs Fidelis "
+            "from its tagged GitHub source (see README)",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_public_install_truth.py
+++ b/tests/test_public_install_truth.py
@@ -1,5 +1,6 @@
-"""Keep the public installation path bound to this repository, not PyPI."""
+"""Keep public install and evidence links bound to this repository."""
 
+import json
 from pathlib import Path
 
 
@@ -26,10 +27,18 @@ def test_primary_surfaces_pin_current_github_source_release():
         assert "python3 -m pip install ." in text, path
 
 
-def test_current_readme_links_only_shipped_benchmark_receipt():
+def test_current_readme_links_shipped_benchmark_receipts():
     readme = (ROOT / "README.md").read_text()
     assert "bench/runs/zeroLLM-full-20260424/aggregate.json" not in readme
-    assert (ROOT / "experiments" / "zeroLLM-FLAGSHIP-evidence" / "SUMMARY.json").is_file()
+    retrieval = ROOT / "bench" / "runs" / "runP-v35" / "aggregate.json"
+    qa = ROOT / "experiments" / "zeroLLM-FLAGSHIP-evidence" / "SUMMARY.json"
+    assert retrieval.is_file()
+    assert qa.is_file()
+    assert "bench/runs/runP-v35/aggregate.json" in readme
+    assert "experiments/zeroLLM-FLAGSHIP-evidence/SUMMARY.json" in readme
+    recall = json.loads(retrieval.read_text())["stage1_metrics"]["recall_any"]
+    assert recall["R@1"] == 0.832
+    assert recall["R@5"] == 0.983
 
 
 def test_readme_scopes_no_telemetry_claim_to_documented_service_path():

--- a/tests/test_public_install_truth.py
+++ b/tests/test_public_install_truth.py
@@ -1,0 +1,39 @@
+"""Keep the public installation path bound to this repository, not PyPI."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_SURFACES = (
+    ROOT / "README.md",
+    ROOT / "llms.txt",
+    ROOT / "agents.md",
+    ROOT / "docs" / "full-reference.md",
+)
+
+
+def test_public_surfaces_do_not_install_unrelated_pypi_project():
+    for path in PUBLIC_SURFACES:
+        text = path.read_text()
+        assert "pip install fidelis" not in text, path
+        assert "pypi.org/project/fidelis" not in text, path
+
+
+def test_primary_surfaces_pin_current_github_source_release():
+    for path in (ROOT / "README.md", ROOT / "llms.txt", ROOT / "docs" / "full-reference.md"):
+        text = path.read_text()
+        assert "--branch v0.0.91 --depth 1" in text, path
+        assert "python3 -m pip install ." in text, path
+
+
+def test_current_readme_links_only_shipped_benchmark_receipt():
+    readme = (ROOT / "README.md").read_text()
+    assert "bench/runs/zeroLLM-full-20260424/aggregate.json" not in readme
+    assert (ROOT / "experiments" / "zeroLLM-FLAGSHIP-evidence" / "SUMMARY.json").is_file()
+
+
+def test_readme_scopes_no_telemetry_claim_to_documented_service_path():
+    readme = (ROOT / "README.md").read_text()
+    assert "no outbound network calls" not in readme
+    assert "Direct server launches need explicit telemetry settings" in readme
+    assert "MEM0_TELEMETRY=False" in readme


### PR DESCRIPTION
## Why

The PyPI project named `fidelis` is an unrelated NGdust package, while current Fidelis docs and runtime error messages directed users to `pip install fidelis`. The public surfaces also mixed v0.0.9/v0.0.91 identity, linked one dead benchmark path, and overstated the local-data/compliance and telemetry boundaries.

## What changed

- Replace every primary install path with the tagged GitHub v0.0.91 source checkout and add an explicit unrelated-PyPI warning.
- Align README, reference docs, LLM-facing docs, CI comments, and package messages to v0.0.91.
- Bind the 83.2% R@1 / 98.3% R@5 and end-to-end QA claims to receipts that actually ship in this repository.
- Narrow local-data and compliance wording: the default zero-LLM path keeps memory local, but the architecture does not itself confer SOC 2 or HIPAA compliance.
- State the exact telemetry boundary: `fidelis init` installs service settings that disable mem0/Chroma telemetry; direct server launches need the same environment settings explicitly.
- Remove superseded cross-project proof language and add regression coverage for installation, evidence-link, and telemetry wording.

## Deliberate scope boundary

This is a public-truth and source-install PR. It does not change retrieval behavior, server lifecycle behavior, telemetry code, or benchmark outputs.

The SIGTERM shutdown test timeout is explicitly **outside this PR**. It reproduces in a fresh Python 3.12 environment on the exact unmodified public base `2ec3850fa0cf3a3e38131371beebf96fffacb581`, and the corrected source-install path does not depend on a runtime fix. Track that baseline defect separately.

## Validation

- Ruff: PASS.
- Final deterministic suite: **351 passed, 3 skipped**, with the independently reproduced baseline SIGTERM timeout test deselected.
- Fresh source install: PASS.
- Wheel and sdist build, clean installs, metadata/runtime/CLI smoke: PASS.
- New public-install contract assertions: PASS.
- Exact focused review of `2ec3850..ba4491f`: **PASS, 0 findings**.

## Public nonclaims

- Hermes Labs Fidelis is not published on PyPI under `fidelis`.
- This PR does not publish a package, move a tag, or change a release.
- “Zero-LLM” applies to the default retrieval hot path, not the caller's answering model.
- Local-first architecture can reduce third-party exposure; it is not a compliance certification.
