### PR TITLE
fix: preserve writes when extraction returns no facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+- Preserve `/add` input verbatim when the extraction model returns no facts,
+  expose the degraded fallback through HTTP and CLI, and apply the same
+  no-silent-loss rule during queued-write replay.
 - Correct every current install surface to use tagged GitHub source; the PyPI
   project named `fidelis` is unrelated to Hermes Labs Fidelis.
 - Align public package status with v0.0.91 and remove a dead benchmark link.

--- a/README.md
+++ b/README.md
@@ -175,9 +175,24 @@ The full init-to-first-recall cycle is under 60 seconds once Ollama is up. No me
 ```bash
 fidelis recall "what did the user say about Sarah"
 fidelis query  "Sarah" --limit 5
+fidelis add    "raw text to extract into memories"
 fidelis health
 fidelis seed   ~/memory/   ~/notes/
 ```
+
+`fidelis add` normally stores facts produced by the configured extraction
+model. If extraction returns no facts, Fidelis preserves the original input
+verbatim instead of silently losing it. The command still exits 0 because the
+write succeeded, but stdout reports a stable degraded status:
+
+```text
+status=stored degraded=verbatim-fallback-empty-extraction id=<uuid> count=1
+```
+
+Automation that requires successful extraction must inspect `degraded`; exit 0
+means the memory was stored, not necessarily that extraction succeeded. Because
+mem0 does not distinguish a swallowed extractor failure from a legitimate
+zero-fact result, the fallback intentionally favors durability.
 
 Python helper for direct integration:
 

--- a/docs/full-reference.md
+++ b/docs/full-reference.md
@@ -661,8 +661,22 @@ Request:
 
 Response:
 ```json
-{"count": 3, "memories": ["extracted fact 1", "extracted fact 2", "extracted fact 3"]}
+{"status": "stored", "count": 3, "memories": ["extracted fact 1", "extracted fact 2", "extracted fact 3"]}
 ```
+
+If extraction returns no facts, Fidelis stores the original input verbatim so
+the write is not silently lost. The response remains HTTP 200 because storage
+succeeded, and adds an explicit degraded marker and record ID:
+
+```json
+{"status": "stored", "count": 1, "memories": ["free-form text to remember"], "degraded": "verbatim-fallback-empty-extraction", "id": "abc123..."}
+```
+
+The CLI exits 0 for this result and prints a stable `status=stored
+degraded=verbatim-fallback-empty-extraction id=<uuid> count=1` line. Callers
+that require extracted facts must inspect `degraded`; exit 0 establishes only
+that the input was stored. mem0 does not distinguish a swallowed extractor
+failure from a legitimate zero-fact result, so this fallback favors durability.
 
 ---
 
@@ -869,12 +883,18 @@ records 0% escalation by construction.
 All writes go through `fidelis.degrade.safe_add`:
 
 - Dependency up → memory stored + response returned
+- Extraction returns no facts → original input stored verbatim and response
+  marked `degraded=verbatim-fallback-empty-extraction`
 - Dependency down → write queued to `~/.cogito/queue/<ts>-<uuid>.json`,
   success returned; no data lost
+- Queue replay uses the same verbatim fallback and removes a queued item only
+  after extraction or fallback storage succeeds
 - Call `fidelis.degrade.replay_queue(memory, user_id)` when the
   dependency recovers to drain
 
-See `tests/test_graceful_degrade.py` for the state machine and
+See `tests/test_graceful_degrade.py` and
+`tests/test_write_fallback_contract.py` for the state machine and public
+fallback contract, and
 `tests/test_graceful_degrade_corruption.py` for the corrupt-queue-file
 branch coverage.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 [project.optional-dependencies]
 ollama = []  # no extra deps — Ollama runs locally
 hybrid = ["bm25s>=0.2"]  # BM25 fusion for recall_hybrid; degrades gracefully if absent
-dev = ["pytest", "pytest-asyncio", "httpx", "ruff"]
+dev = ["pytest", "pytest-asyncio", "httpx", "ruff==0.15.22"]
 
 [project.scripts]
 fidelis = "fidelis.cli:main"

--- a/src/fidelis/cli.py
+++ b/src/fidelis/cli.py
@@ -118,6 +118,18 @@ def cmd_query(args):
 def cmd_add(args):
     text = " ".join(args.text)
     result = _post("/add", {"text": text})
+    if result.get("degraded"):
+        print(
+            f"status={result.get('status', 'stored')} "
+            f"degraded={result['degraded']} "
+            f"id={result.get('id', '?')} count={result.get('count', 0)}"
+        )
+        print(
+            "Warning: extraction did not produce facts; the original input "
+            "was stored verbatim as a durability fallback.",
+            file=sys.stderr,
+        )
+        return
     print(f"Added {result.get('count', 0)} memories.")
     for m in result.get("memories", []):
         print(f"  → {m}")

--- a/src/fidelis/degrade.py
+++ b/src/fidelis/degrade.py
@@ -16,6 +16,8 @@ import time
 import uuid
 from pathlib import Path
 
+from chromadb.errors import DuplicateIDError
+
 MAX_ATTEMPTS = 5
 
 
@@ -93,6 +95,20 @@ def dead_count() -> int:
     return len(list(ddir.glob("*.json")))
 
 
+def _usable_extracted_memories(result) -> list[str]:
+    """Return only non-blank facts from mem0's optional result envelope."""
+    if not isinstance(result, dict):
+        return []
+    extracted = []
+    for item in result.get("results") or []:
+        if not isinstance(item, dict):
+            continue
+        value = item.get("memory")
+        if isinstance(value, str) and value.strip():
+            extracted.append(value)
+    return extracted
+
+
 def safe_add(memory, text: str, user_id: str, kind: str = "add") -> dict:
     """Try to write through mem0; on dependency failure, queue locally.
 
@@ -111,7 +127,24 @@ def safe_add(memory, text: str, user_id: str, kind: str = "add") -> dict:
             )
             return {"status": "stored", "id": mid, "extracted": [text]}
         result = memory.add(text, user_id=user_id)
-        extracted = [m.get("memory", "") for m in result.get("results", [])]
+        extracted = _usable_extracted_memories(result)
+        if not extracted:
+            # mem0 can swallow an extraction-model failure and return no facts.
+            # Preserve the caller's input through the same verbatim path used
+            # by queued-write replay, but mark that extraction did not succeed.
+            mid = str(uuid.uuid4())
+            _replay_verbatim(memory, {
+                "id": mid,
+                "text": text,
+                "user_id": user_id,
+                "kind": "add",
+            })
+            return {
+                "status": "stored",
+                "id": mid,
+                "extracted": [text],
+                "degraded": "verbatim-fallback-empty-extraction",
+            }
         return {"status": "stored", "extracted": extracted}
     except Exception as e:
         mid = queue_write(text, user_id, kind=kind)
@@ -152,9 +185,12 @@ def replay_queue(memory, user_id: str) -> dict:
             if rec.get("kind") == "store":
                 _replay_verbatim(memory, rec)
             else:
+                add_result = None
                 try:
-                    memory.add(rec["text"], user_id=rec["user_id"])
+                    add_result = memory.add(rec["text"], user_id=rec["user_id"])
                 except Exception:
+                    add_result = None
+                if not _usable_extracted_memories(add_result):
                     _replay_verbatim(memory, rec)
                     replayed_verbatim += 1
             qfile.unlink()
@@ -213,6 +249,15 @@ def _replay_verbatim(memory, rec: dict) -> None:
     except Exception as e:
         # chromadb raises on duplicate ids — that's a successful prior insert.
         # Any other error propagates so the caller can count it as a failure.
-        if "exist" in str(e).lower() or "duplicate" in str(e).lower():
+        if isinstance(e, DuplicateIDError):
+            return
+        message = str(e).lower()
+        duplicate_markers = (
+            "existing embedding id",
+            "duplicate embedding id",
+            "duplicate id",
+            "id already exists",
+        )
+        if any(marker in message for marker in duplicate_markers):
             return
         raise

--- a/src/fidelis/server.py
+++ b/src/fidelis/server.py
@@ -291,11 +291,15 @@ def make_handler(memory: object, cfg: dict) -> type:
                         }, 202)  # 202 Accepted: write deferred
                     else:
                         extracted = result.get("extracted", [])
-                        self._json({
+                        response = {
                             "status": "stored",
                             "count": len(extracted),
                             "memories": extracted,
-                        })
+                        }
+                        if result.get("degraded"):
+                            response["degraded"] = result["degraded"]
+                            response["id"] = result.get("id")
+                        self._json(response)
 
                 else:
                     self._json({"error": "not found"}, 404)

--- a/tests/test_graceful_degrade.py
+++ b/tests/test_graceful_degrade.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 
 import pytest
+from chromadb.errors import DuplicateIDError
 
 from fidelis import degrade
 
@@ -31,6 +32,59 @@ class _WorkingMemory:
         return {"results": [{"memory": text}]}
 
 
+class _RecordingVectorStore:
+    def __init__(self):
+        self.inserted = []
+
+    def insert(self, *, vectors, payloads, ids):
+        self.inserted.append({"vectors": vectors, "payloads": payloads, "ids": ids})
+
+
+class _WorkingEmbedder:
+    def embed(self, text, *args, **kwargs):
+        return [0.0] * 8
+
+
+class _EmptyExtractionMemory:
+    def __init__(self, add_result):
+        self.add_result = add_result
+        self.embedding_model = _WorkingEmbedder()
+        self.vector_store = _RecordingVectorStore()
+
+    def add(self, text, user_id):
+        return self.add_result
+
+
+class _BrokenFallbackMemory(_EmptyExtractionMemory):
+    class _BrokenEmbedder:
+        def embed(self, text, *args, **kwargs):
+            raise ConnectionError("embedding unavailable")
+
+    def __init__(self):
+        super().__init__({"results": []})
+        self.embedding_model = self._BrokenEmbedder()
+
+
+class _BrokenInsertMemory(_EmptyExtractionMemory):
+    class _BrokenStore:
+        def insert(self, *, vectors, payloads, ids):
+            raise RuntimeError("collection does not exist")
+
+    def __init__(self):
+        super().__init__({"results": []})
+        self.vector_store = self._BrokenStore()
+
+
+class _DuplicateInsertMemory(_EmptyExtractionMemory):
+    class _DuplicateStore:
+        def insert(self, *, vectors, payloads, ids):
+            raise DuplicateIDError(f"Expected IDs to be unique, found duplicates of: {ids[0]}")
+
+    def __init__(self):
+        super().__init__({"results": []})
+        self.vector_store = self._DuplicateStore()
+
+
 def test_add_queues_when_ollama_down(temp_queue):
     """The 2026-04-19 incident regression test."""
     mem = _BrokenOllamaMemory()
@@ -47,6 +101,53 @@ def test_add_succeeds_when_dependency_up(temp_queue):
     assert result["status"] == "stored"
     assert result["extracted"] == ["another memory"]
     assert list(temp_queue.glob("*.json")) == []
+
+
+@pytest.mark.parametrize(
+    "add_result",
+    [
+        {"results": []},
+        None,
+        {"results": [{"memory": ""}]},
+        {"results": [{"memory": None}]},
+    ],
+)
+def test_empty_extraction_falls_back_to_verbatim(temp_queue, add_result):
+    mem = _EmptyExtractionMemory(add_result)
+
+    result = degrade.safe_add(mem, "durable original text", user_id="agent")
+
+    assert result["status"] == "stored"
+    assert result["extracted"] == ["durable original text"]
+    assert result["degraded"] == "verbatim-fallback-empty-extraction"
+    assert result["id"]
+    assert len(mem.vector_store.inserted) == 1
+    assert mem.vector_store.inserted[0]["payloads"] == [
+        {"data": "durable original text", "user_id": "agent"}
+    ]
+    assert list(temp_queue.glob("*.json")) == []
+
+
+def test_failed_verbatim_fallback_queues_original_text(temp_queue):
+    mem = _BrokenFallbackMemory()
+
+    result = degrade.safe_add(mem, "queue this exact text", user_id="agent")
+
+    assert result["status"] == "queued"
+    queued = list(temp_queue.glob("*.json"))
+    assert len(queued) == 1
+    assert "queue this exact text" in queued[0].read_text()
+
+
+def test_non_duplicate_insert_failure_queues_original_text(temp_queue):
+    mem = _BrokenInsertMemory()
+
+    result = degrade.safe_add(mem, "preserve after insert failure", user_id="agent")
+
+    assert result["status"] == "queued"
+    queued = list(temp_queue.glob("*.json"))
+    assert len(queued) == 1
+    assert "preserve after insert failure" in queued[0].read_text()
 
 
 def test_replay_drains_queue_when_dependency_recovers(temp_queue):
@@ -68,3 +169,50 @@ def test_replay_keeps_records_when_dependency_still_down(temp_queue):
     summary = degrade.replay_queue(bad, user_id="agent")
     assert summary["replayed"] == 0
     assert summary["remaining"] == 1
+
+
+@pytest.mark.parametrize(
+    "add_result",
+    [
+        {"results": []},
+        {"results": [{"memory": ""}]},
+        {"results": [{"memory": None}]},
+    ],
+)
+def test_replay_empty_extraction_falls_back_before_deleting_queue(temp_queue, add_result):
+    degrade.queue_write("queued durable text", user_id="agent")
+    mem = _EmptyExtractionMemory(add_result)
+
+    summary = degrade.replay_queue(mem, user_id="agent")
+
+    assert summary["replayed"] == 1
+    assert summary["replayed_verbatim"] == 1
+    assert summary["remaining"] == 0
+    assert len(mem.vector_store.inserted) == 1
+    assert mem.vector_store.inserted[0]["payloads"] == [
+        {"data": "queued durable text", "user_id": "agent"}
+    ]
+
+
+def test_replay_non_duplicate_insert_failure_keeps_queue_record(temp_queue):
+    degrade.queue_write("queued after insert failure", user_id="agent")
+    mem = _BrokenInsertMemory()
+
+    summary = degrade.replay_queue(mem, user_id="agent")
+
+    assert summary["replayed"] == 0
+    assert summary["failed"] == 1
+    assert summary["remaining"] == 1
+    assert degrade.queued_count() == 1
+
+
+def test_replay_duplicate_id_acknowledges_prior_insert(temp_queue):
+    degrade.queue_write("already inserted before replay retry", user_id="agent")
+    mem = _DuplicateInsertMemory()
+
+    summary = degrade.replay_queue(mem, user_id="agent")
+
+    assert summary["replayed"] == 1
+    assert summary["replayed_verbatim"] == 1
+    assert summary["failed"] == 0
+    assert summary["remaining"] == 0

--- a/tests/test_write_fallback_contract.py
+++ b/tests/test_write_fallback_contract.py
@@ -1,0 +1,139 @@
+"""Public write-fallback contract, exercised without Ollama or ChromaDB."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from unittest.mock import MagicMock
+
+from fidelis import cli
+from fidelis.server import make_handler
+
+
+class _Hit:
+    def __init__(self, text: str):
+        self.payload = {"data": text, "user_id": "agent"}
+        self.score = 0.0
+
+
+class _VectorStore:
+    def __init__(self):
+        self.rows: list[tuple[str, str]] = []
+
+    def insert(self, *, vectors, payloads, ids):
+        del vectors
+        self.rows.extend((record_id, payload["data"]) for record_id, payload in zip(ids, payloads))
+
+    def search(self, *, query, vectors, top_k, filters):
+        del query, vectors, filters
+        return [_Hit(text) for _, text in self.rows[:top_k]]
+
+
+class _Embedder:
+    def embed(self, text, *args, **kwargs):
+        del text, args, kwargs
+        return [0.0] * 8
+
+
+class _EmptyExtractionMemory:
+    def __init__(self):
+        self.embedding_model = _Embedder()
+        self.vector_store = _VectorStore()
+
+    def add(self, text, user_id):
+        del text, user_id
+        return {"results": []}
+
+
+def _post_to_handler(handler_cls, path: str, body: dict) -> dict:
+    payload = json.dumps(body).encode()
+
+    class _Capture:
+        def __init__(self):
+            self.written: list[bytes] = []
+
+        def write(self, data):
+            self.written.append(data)
+
+        def flush(self):
+            pass
+
+    handler = handler_cls.__new__(handler_cls)
+    handler.wfile = _Capture()
+    handler.rfile = io.BytesIO(payload)
+    handler.headers = {
+        "Content-Length": str(len(payload)),
+        "Content-Type": "application/json",
+    }
+    handler.path = path
+    handler.requestline = f"POST {path} HTTP/1.1"
+    handler.server = MagicMock()
+    handler.client_address = ("127.0.0.1", 12345)
+    handler.command = "POST"
+    handler.send_response = lambda *args, **kwargs: None
+    handler.send_header = lambda *args, **kwargs: None
+    handler.end_headers = lambda: None
+    handler.do_POST()
+    return json.loads(b"".join(handler.wfile.written))
+
+
+def test_add_fallback_is_explicit_and_recallable_deterministically():
+    memory = _EmptyExtractionMemory()
+    handler_cls = make_handler(memory, {"user_id": "agent", "vocab_map": {}})
+
+    stored = _post_to_handler(handler_cls, "/add", {"text": "synthetic durable fact"})
+
+    assert stored["status"] == "stored"
+    assert stored["count"] == 1
+    assert stored["memories"] == ["synthetic durable fact"]
+    assert stored["degraded"] == "verbatim-fallback-empty-extraction"
+    assert stored["id"]
+
+    first = _post_to_handler(handler_cls, "/query", {"text": "durable", "limit": 3})
+    second = _post_to_handler(handler_cls, "/query", {"text": "durable", "limit": 3})
+    assert first == second
+    assert first["memories"][0]["text"] == "synthetic durable fact"
+
+
+def test_cli_degraded_write_exits_zero_with_stable_status(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cli,
+        "_post",
+        lambda path, payload: {
+            "status": "stored",
+            "count": 1,
+            "memories": [payload["text"]],
+            "degraded": "verbatim-fallback-empty-extraction",
+            "id": "fallback-uuid",
+        },
+    )
+
+    cli.cmd_add(argparse.Namespace(text=["raw", "input"]))
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == (
+        "status=stored degraded=verbatim-fallback-empty-extraction "
+        "id=fallback-uuid count=1"
+    )
+    assert "stored verbatim" in captured.err.lower()
+    assert "Added" not in captured.out
+
+
+def test_cli_successful_extraction_output_is_unchanged(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cli,
+        "_post",
+        lambda path, payload: {
+            "status": "stored",
+            "count": 1,
+            "memories": ["extracted fact"],
+        },
+    )
+
+    cli.cmd_add(argparse.Namespace(text=["raw", "input"]))
+
+    captured = capsys.readouterr()
+    assert "Added 1 memories." in captured.out
+    assert "extracted fact" in captured.out
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

- preserve the original input through the existing verbatim vector-store path when extraction returns no usable facts
- report the successful degraded write consistently through `/add` and `fidelis add`, while keeping the CLI exit code at 0
- make queued replay delete records only after extraction or verbatim insertion succeeds, including idempotent duplicate-ID retries
- pin the dev-only Ruff dependency to the last known-green release, preventing unrelated lint-rule drift from blocking this PR

## User-visible contract

When extraction returns `None`, no results, or only blank/null facts, `/add` returns HTTP 200 with `status=stored`, the fallback record `id`, and `degraded=verbatim-fallback-empty-extraction`. The CLI emits:

```text
status=stored degraded=verbatim-fallback-empty-extraction id=<uuid> count=1
```

It also warns on stderr that extraction failed but verbatim storage succeeded. Exit status remains 0 so automation does not retry an already stored write.

## Verification

- red regression state before the source fix: 6 failed, 5 passed
- focused requested suite: 24 passed
- expanded fallback/recall suite: 51 passed
- offline deterministic suite: 499 passed, 5 deselected, 1 xpassed
- `ruff check src/ tests/`
- `ruff==0.15.22 check src/ tests/`
- `python -m compileall -q src tests`
- `git diff --check`

The fixtures establish mechanism conformance only; they do not establish natural-corpus extraction or retrieval accuracy. Live Ollama, model-backed, and live server tests were excluded to keep this evaluation synthetic and deterministic.

## Scope

No runtime dependency, version, MCP, session retrieval, injection, or harness change is included. The Ruff pin is a dev-only PRE_EXISTING_EXPOSED CI reproducibility correction; it does not alter the write-fallback behavior.
