### PR TITLE
Release fidelis v0.0.92

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,16 @@
 name: CI
 
-# Hermetic CI for v0.0.91: runs on fresh Ubuntu and macOS runners. Proves the
+# Hermetic CI for v0.0.92: runs on fresh Ubuntu and macOS runners. Proves the
 # fidelis package installs cleanly from source on a box that has never seen it
 # before — the equivalent of a beta tester installing the tagged source. Tests
 # that require a live Ollama or LLM endpoint are excluded by directory; the
-# rest (~470) must pass on every commit.
+# rest (~370) must pass on every commit.
 #
 # What this catches:
 #   - missing dependencies (e.g. the `ollama` python lib that crashed our
 #     fresh-venv smoke test before we added it to pyproject)
 #   - macOS-only or Linux-only path bugs
-#   - Python-version regressions across 3.10/3.11/3.12
+#   - Python-version regressions across 3.10 through 3.14
 #   - lint regressions
 #   - silent test-collection failures
 #
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+## v0.0.92 — 2026-08-04
+
 - Preserve `/add` input verbatim when the extraction model returns no facts,
   expose the degraded fallback through HTTP and CLI, and apply the same
   no-silent-loss rule during queued-write replay.
@@ -9,8 +11,9 @@
   project named `fidelis` is unrelated to Hermes Labs Fidelis.
 - Align public package status with v0.0.91 and remove a dead benchmark link.
 - Narrow local-data and compliance wording to the demonstrated boundary.
-- Document that direct server launches need the telemetry environment settings
-  which `fidelis init` installs automatically.
+- Default mem0 telemetry off for direct server launches so SIGTERM completes
+  cleanly, while preserving explicit opt-in; document the remaining Chroma
+  settings and extend CI coverage through Python 3.14.
 - Remove cross-project proof language from current Fidelis presentation.
 - Add a regression test for the public installation contract.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stop re-explaining context to your agent. fidelis returns your original notes ve
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Status: pre-release](https://img.shields.io/badge/status-pre--release-orange)](#known-limitations)
-[![Tests: 486 passing](https://img.shields.io/badge/tests-486%20passing-brightgreen)](tests/)
+[![CI tests: 368 passing](https://img.shields.io/badge/CI%20tests-368%20passing-brightgreen)](tests/)
 [![Made by Hermes Labs](https://img.shields.io/badge/made%20by-Hermes%20Labs-purple)](https://hermes-labs.ai)
 
 ```
@@ -41,8 +41,8 @@ What fidelis is:
 brew install ollama && ollama serve &
 ollama pull nomic-embed-text
 
-# 1. install the v0.0.91 GitHub source release (not the unrelated PyPI project)
-git clone --branch v0.0.91 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
+# 1. install the v0.0.92 GitHub source release (not the unrelated PyPI project)
+git clone --branch v0.0.92 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
 cd fidelis
 python3 -m pip install .
 fidelis init                  # background service (launchd / systemd)
@@ -58,7 +58,7 @@ fidelis mcp install           # wires Claude Code
 
 Linux users swap `brew install ollama` for the equivalent install from [ollama.com](https://ollama.com). [See Requirements](#requirements).
 
-v0.0.91 - GitHub source release; not published on PyPI.
+v0.0.92 - GitHub source release; not published on PyPI.
 
 ## What you notice immediately
 
@@ -223,15 +223,16 @@ After `fidelis init`:
 
 To stop: `fidelis init --uninstall`. To wipe: `rm -rf ~/.cogito ~/.fidelis`.
 
-## Known limitations (v0.0.91)
+## Known limitations (v0.0.92)
 
 - **Pre-release.** Python function names and CLI commands may change. Pin the version if you build on it.
 - **Best on macOS Sequoia / Ubuntu 24.04 LTS.** Other OSes likely work but aren't gate-tested.
-- **Direct server launches need explicit telemetry settings.** `fidelis init`
-  installs a service with mem0 and Chroma telemetry disabled. If you run
-  `fidelis-server` directly, set `MEM0_TELEMETRY=False`,
-  `ANONYMIZED_TELEMETRY=False`, and `CHROMA_TELEMETRY_DISABLED=True` before
-  startup to get the same boundary.
+- **Direct server launches disable mem0 telemetry by default.** This matches
+  the service installed by `fidelis init` and avoids telemetry exit handlers
+  delaying graceful shutdown. An explicit `MEM0_TELEMETRY=True` still opts in.
+  For the same boundary across Chroma, set `ANONYMIZED_TELEMETRY=False` and
+  `CHROMA_TELEMETRY_DISABLED=True` before a direct launch; `fidelis init`
+  includes all three settings automatically.
 - **Temporal-reasoning and preference questions are the weakest qtypes** in the QA scaffold (TR ~58%, Pref ~37% on the full eval). Single-session and knowledge-update qtypes are strong (95–100%).
 - **The optional LLM tier ("flagship" mode) currently escalates ~80% of queries instead of the intended ~10%** - an 8× cost miss we're transparent about. The default zero-LLM tier is unaffected.
 - **qwen3.5:9b in thinking mode does not reliably follow the literal hedge instruction** in the Fidelis Scaffold. Use Claude, an OpenAI-format API, or non-thinking-mode local models for reliable hedging.

--- a/docs/full-reference.md
+++ b/docs/full-reference.md
@@ -1,6 +1,6 @@
 # fidelis
 
-> **Package release v0.0.91 (2026-06-18).** The separately versioned Fidelis
+> **Package release v0.0.92 (2026-08-04).** The separately versioned Fidelis
 > Scaffold protocol remains v0.1.0 in the API and examples below. Hermes Labs
 > Fidelis is distributed from tagged GitHub source and is not the unrelated
 > PyPI project named `fidelis`.
@@ -8,7 +8,7 @@
 ## 60-second quickstart
 
 ```bash
-git clone --branch v0.0.91 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
+git clone --branch v0.0.92 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
 cd fidelis
 python3 -m pip install .
 fidelis init                  # installs + starts the service (launchd/systemd)
@@ -104,6 +104,11 @@ Full 470-question evaluation in progress; smoke evidence + machine-readable summ
 A separate `/recall` atomic path is purpose-built for short-fact lookup (not session retrieval); it scores 85% R@1 combined with the snapshot layer on a 31-case internal atomic-fact eval. This is a secondary surface; the headline retrieval number above (83.2% R@1 on the full 470-question LongMemEval-S) is the authoritative session-retrieval measurement.
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
+
+CI exercises Python 3.10 through 3.14 on Linux and macOS. Direct
+`fidelis-server` launches default `MEM0_TELEMETRY` to `False`, matching the
+generated service configuration and preventing telemetry cleanup from delaying
+graceful process shutdown. Set `MEM0_TELEMETRY=True` explicitly to opt in.
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Made by Hermes Labs](https://img.shields.io/badge/made%20by-Hermes%20Labs-purple)](https://hermes-labs.ai)
 
@@ -258,7 +263,7 @@ Key results:
 **1. Install**
 
 ```bash
-git clone --branch v0.0.91 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
+git clone --branch v0.0.92 --depth 1 https://github.com/hermes-labs-ai/fidelis.git
 cd fidelis
 python3 -m pip install .
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -158,7 +158,7 @@ All by Hermes Labs (https://hermes-labs.ai).
 
 ## Install
 
-git clone --branch v0.0.91 --depth 1 https://github.com/hermes-labs-ai/fidelis.git && cd fidelis && python3 -m pip install .
+git clone --branch v0.0.92 --depth 1 https://github.com/hermes-labs-ai/fidelis.git && cd fidelis && python3 -m pip install .
 Python 3.10+. MIT license.
 Repo: https://github.com/hermes-labs-ai/fidelis
 Package warning: NOT published on PyPI. The PyPI project named "fidelis" is unrelated (NGdust/fidelis).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fidelis"
-version = "0.0.91"
+version = "0.0.92"
 description = "Faithful agent memory — zero-LLM retrieval default (83.2% R@1 on LongMemEval_S, $0/query, fully local), integer-pointer fidelity on the optional LLM tier. By Hermes Labs."
 readme = "README.md"
 license = { text = "MIT" }
@@ -22,6 +22,11 @@ classifiers = [
   "Intended Audience :: Developers",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "mem0ai>=2.0.0,<3.0",

--- a/src/fidelis/__init__.py
+++ b/src/fidelis/__init__.py
@@ -14,7 +14,7 @@ Data paths and env var names retain the ``cogito`` prefix for continuity
 with existing deployments.
 """
 
-__version__ = "0.0.91"
+__version__ = "0.0.92"
 
 from fidelis.recall import recall  # noqa: F401
 

--- a/src/fidelis/server.py
+++ b/src/fidelis/server.py
@@ -65,6 +65,12 @@ def _boot(cfg: dict) -> object:
     if site and site not in sys.path:
         sys.path.insert(0, site)
 
+    # Match the service installed by `fidelis init`: keep mem0 telemetry off
+    # unless an operator explicitly opts in. Besides preserving the documented
+    # local-first boundary for direct launches, this prevents posthog's exit
+    # handlers from delaying process termination after a graceful SIGTERM.
+    os.environ.setdefault("MEM0_TELEMETRY", "False")
+
     from mem0 import Memory  # type: ignore
 
     m = Memory.from_config(mem0_config(cfg))

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -13,10 +13,13 @@ import socket
 import subprocess
 import sys
 import time
+import types
 import urllib.request
 from pathlib import Path
 
 import pytest
+
+from fidelis import server
 
 
 def _free_port() -> int:
@@ -81,7 +84,11 @@ def test_sigterm_triggers_clean_shutdown(tmp_path: Path):
             return_code = proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
-            pytest.fail("SIGTERM did not stop the server within 5s — graceful shutdown regressed")
+            output, _ = proc.communicate(timeout=5)
+            pytest.fail(
+                "SIGTERM did not stop the server within 5s — graceful shutdown regressed.\n"
+                f"output tail:\n{output[-2000:]}"
+            )
 
         # Process must have exited with 0 (clean) — anything else means an
         # unhandled exception killed it instead of the signal handler.
@@ -108,3 +115,35 @@ def test_signal_handlers_registered_in_main():
     assert "signal.SIGINT" in src, "SIGINT handler missing from server.main()"
     assert "httpd.shutdown" in src, "graceful httpd.shutdown call missing"
     assert "Stopped cleanly" in src, "clean-stop marker missing — friend will not see exit signal"
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [(None, "False"), ("True", "True")],
+)
+def test_boot_defaults_mem0_telemetry_off_but_preserves_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str | None,
+    expected: str,
+):
+    """Direct launches use the service's telemetry-off default without
+    overriding an operator's explicit choice."""
+    if configured is None:
+        monkeypatch.delenv("MEM0_TELEMETRY", raising=False)
+    else:
+        monkeypatch.setenv("MEM0_TELEMETRY", configured)
+
+    seen: dict[str, object] = {}
+
+    class FakeMemory:
+        @staticmethod
+        def from_config(config):
+            seen["config"] = config
+            return "memory"
+
+    monkeypatch.setitem(sys.modules, "mem0", types.SimpleNamespace(Memory=FakeMemory))
+    monkeypatch.setattr(server, "mem0_config", lambda cfg: cfg)
+
+    assert server._boot({"test": True}) == "memory"
+    assert seen["config"] == {"test": True}
+    assert server.os.environ["MEM0_TELEMETRY"] == expected

--- a/tests/test_public_install_truth.py
+++ b/tests/test_public_install_truth.py
@@ -23,7 +23,7 @@ def test_public_surfaces_do_not_install_unrelated_pypi_project():
 def test_primary_surfaces_pin_current_github_source_release():
     for path in (ROOT / "README.md", ROOT / "llms.txt", ROOT / "docs" / "full-reference.md"):
         text = path.read_text()
-        assert "--branch v0.0.91 --depth 1" in text, path
+        assert "--branch v0.0.92 --depth 1" in text, path
         assert "python3 -m pip install ." in text, path
 
 
@@ -41,8 +41,10 @@ def test_current_readme_links_shipped_benchmark_receipts():
     assert recall["R@5"] == 0.983
 
 
-def test_readme_scopes_no_telemetry_claim_to_documented_service_path():
+def test_readme_scopes_no_telemetry_claim_to_documented_defaults():
     readme = (ROOT / "README.md").read_text()
     assert "no outbound network calls" not in readme
-    assert "Direct server launches need explicit telemetry settings" in readme
-    assert "MEM0_TELEMETRY=False" in readme
+    assert "Direct server launches disable mem0 telemetry by default" in readme
+    assert "MEM0_TELEMETRY=True" in readme
+    assert "ANONYMIZED_TELEMETRY=False" in readme
+    assert "CHROMA_TELEMETRY_DISABLED=True" in readme


### PR DESCRIPTION
## Summary

- release the accumulated public-main reliability fixes as `v0.0.92`, including no-silent-loss verbatim fallback for empty extraction
- default mem0 telemetry off for direct server launches so graceful SIGTERM completes; explicit opt-in remains available
- extend the CI compatibility matrix through Python 3.14 on Linux and macOS
- align package metadata, install instructions, reference docs, and changelog with the GitHub-source release

Hermes Labs Fidelis remains distributed from tagged GitHub source. This does not publish to the unrelated PyPI project named `fidelis`.

## Verification

- Python 3.11 installed-package CI suite: `368 passed, 3 skipped`
- Python 3.14 installed-package CI suite: `368 passed, 3 skipped` (one upstream Chroma deprecation warning)
- graceful-shutdown regression on Python 3.11: `4 passed`
- graceful-shutdown regression on Python 3.14: `4 passed`
- `ruff check src/ tests/`
- `python -m compileall -q src tests`
- `python -m build` produced `fidelis-0.0.92.tar.gz` and `fidelis-0.0.92-py3-none-any.whl`
- `git diff --check`

The synthetic fallback tests establish mechanism conformance only; no new natural-corpus accuracy claim is made.