### PR TITLE
Publish PyPI distribution as fidelis-memory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+# Manual, tag-driven PyPI release for the `fidelis-memory` distribution
+# (import name and CLI commands stay `fidelis`; only the PyPI listing name
+# differs, because the plain `fidelis` name is squatted by an unrelated
+# project). Triggered by hand via `workflow_dispatch` against an existing
+# `vX.Y.Z` tag — never runs automatically on push, so a release always
+# requires a deliberate dispatch.
+#
+# Flow: checkout the given tag -> verify the tag matches
+# `[project].version` in pyproject.toml -> lint + test (same gate as CI) ->
+# build sdist/wheel -> twine check -> publish to PyPI via Trusted
+# Publishing (OIDC, no stored API token).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to release (e.g. v0.0.92) — must already exist and match pyproject.toml's version"
+        required: true
+        type: string
+
+jobs:
+  build-and-test:
+    name: verify + build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Verify tag matches package version
+        run: |
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG="${{ inputs.tag }}"
+          TAG_VERSION="${TAG#v}"
+          echo "pyproject.toml version: $PKG_VERSION"
+          echo "tag version:            $TAG_VERSION"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match pyproject.toml version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Install fidelis (dev extras — pinned ruff)
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[dev]"
+
+      - name: Ruff lint
+        run: ruff check src/ tests/
+
+      - name: Pytest (CI-runnable suite)
+        env:
+          FIDELIS_QUEUE_DIR: ${{ runner.temp }}/fidelis-release-queue
+        run: |
+          pytest tests/ \
+            --ignore=tests/scaffold/test_e2e_store_query.py \
+            --ignore=tests/scaffold/test_backend_portability.py \
+            --ignore=tests/scaffold/test_anthropic_cache_wire.py \
+            --ignore=tests/scaffold/test_openai_format_compatibility.py \
+            --ignore=tests/scaffold/test_streaming_marker_integrity.py \
+            -q --no-header --tb=line
+
+      - name: Build sdist + wheel
+        run: |
+          pip install --upgrade build twine
+          python -m build
+
+      - name: Twine check
+        run: twine check dist/*
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fidelis-memory-dist
+          path: dist/
+
+  publish-pypi:
+    name: publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: fidelis-memory-dist
+          path: dist/
+
+      - name: Publish to PyPI (Trusted Publishing / OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "fidelis"
+name = "fidelis-memory"
 version = "0.0.92"
 description = "Faithful agent memory — zero-LLM retrieval default (83.2% R@1 on LongMemEval_S, $0/query, fully local), integer-pointer fidelity on the optional LLM tier. By Hermes Labs."
 readme = "README.md"


### PR DESCRIPTION
## Summary
- PyPI's plain "fidelis" name is squatted by an unrelated project, so this publishes under the distribution name `fidelis-memory` instead. Import path (`src/fidelis`), CLI commands (`fidelis`, `fidelis-server`, `fidelis-lpci-server`), and version (0.0.92) are unchanged — only `[project].name` in pyproject.toml changes.
- Adds `.github/workflows/release.yml`: manual `workflow_dispatch` release gate — checks out a given tag, verifies it matches `pyproject.toml`'s version, runs the same ruff+pytest checks as CI, builds sdist/wheel, twine-checks, and publishes to PyPI via Trusted Publishing (OIDC, no stored token).

## Test plan
- [x] `pip install ".[dev]"` clean install
- [x] `ruff check src/ tests/` — passes (pinned ruff==0.15.22 from dev extra)
- [x] `pytest -q` — 368 passed, 3 skipped (matches CI's excluded-tests set)