### PR TITLE
docs: add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "fidelis: local-first, zero-LLM memory for Claude Code and AI agents"
+abstract: "fidelis is a local-first, zero-LLM memory system for Claude Code and other AI agents. It stores notes and sessions in a local memory store and returns original passages verbatim rather than paraphrasing them, using BM25 and dense retrieval with reciprocal rank fusion and no LLM in the default retrieval path. The PyPI distribution name is fidelis-memory; the import name and CLI remain fidelis."
+type: software
+authors:
+  - family-names: "Bosch Rodriguez"
+    given-names: "Rolando"
+    orcid: "https://orcid.org/0009-0005-4896-1112"
+    affiliation: "Hermes Labs"
+license: MIT
+repository-code: "https://github.com/hermes-labs-ai/fidelis"
+version: "0.0.93"
+keywords:
+  - "agent memory"
+  - "zero-LLM retrieval"
+  - "local-first"
+  - "Claude Code"
+  - "verbatim retrieval"
+  - "fidelis-memory"


### PR DESCRIPTION
## What changed

Adds a `CITATION.cff` so GitHub's "Cite this repository" widget works and machine-readable
citation metadata exists for this repo.

## Values

Every field traces to a live source — the repo's own `pyproject.toml` / `LICENSE` / README, or the
Zenodo API. Nothing was inferred from a name or copied from a stale document.

## Verified before commit

- Valid YAML.
- No duplicate top-level keys (YAML silently keeps the last one, which is how a wrong value hides).
- Top-level `type` is `software`, per CFF 1.2.0 — which permits only `software` or `dataset` there.
  Where a repo archives a paper, the paper sits under `preferred-citation` with `type: article`.
- Author block and ORCID match the convention already used across the organization.

`cffconvert` was not available in a safe environment, so schema validation was done by explicit
YAML + key + field checks rather than the official validator. Saying so plainly rather than
implying a validation that did not run.
