### PR TITLE
docs: add CodeMeta metadata

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,49 @@
+{
+  "@context": "https://w3id.org/codemeta/3.1",
+  "@type": "SoftwareSourceCode",
+  "name": "fidelis",
+  "description": "Local-first, zero-LLM memory for Claude Code and AI agents. The source project, import package, and CLI are named fidelis; the PyPI distribution is fidelis-memory.",
+  "codeRepository": "https://github.com/hermes-labs-ai/fidelis",
+  "issueTracker": "https://github.com/hermes-labs-ai/fidelis/issues",
+  "readme": "https://github.com/hermes-labs-ai/fidelis/blob/main/README.md",
+  "continuousIntegration": "https://github.com/hermes-labs-ai/fidelis/actions",
+  "license": "https://spdx.org/licenses/MIT",
+  "version": "0.0.93",
+  "identifier": "https://doi.org/10.5281/zenodo.21873318",
+  "url": "https://github.com/hermes-labs-ai/fidelis",
+  "downloadUrl": "https://pypi.org/project/fidelis-memory/0.0.93/",
+  "releaseNotes": "https://github.com/hermes-labs-ai/fidelis/releases/tag/v0.0.93",
+  "programmingLanguage": "Python",
+  "runtimePlatform": "Python >=3.10",
+  "operatingSystem": [
+    "macOS",
+    "Linux"
+  ],
+  "applicationCategory": "AI agent memory",
+  "keywords": [
+    "agent memory",
+    "zero-LLM retrieval",
+    "local-first",
+    "Claude Code",
+    "verbatim retrieval",
+    "fidelis-memory"
+  ],
+  "author": [
+    {
+      "@id": "https://orcid.org/0009-0005-4896-1112",
+      "@type": "Person",
+      "givenName": "Rolando",
+      "familyName": "Bosch Rodriguez",
+      "affiliation": {
+        "@type": "Organization",
+        "name": "Hermes Labs",
+        "url": "https://hermes-labs.ai"
+      }
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Hermes Labs",
+    "url": "https://hermes-labs.ai"
+  }
+}

--- a/codemeta.json
+++ b/codemeta.json
@@ -19,7 +19,6 @@
     "macOS",
     "Linux"
   ],
-  "applicationCategory": "AI agent memory",
   "keywords": [
     "agent memory",
     "zero-LLM retrieval",

--- a/tests/test_codemeta.py
+++ b/tests/test_codemeta.py
@@ -1,20 +1,33 @@
 """Keep CodeMeta synchronized with the tracked release metadata."""
 
 import json
-import tomllib
+import re
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _toml_string(text, section, key):
+    section_match = re.search(
+        rf"(?ms)^\[{re.escape(section)}\]\n(?P<body>.*?)(?=^\[|\Z)", text
+    )
+    assert section_match, section
+    value_match = re.search(
+        rf'(?m)^{re.escape(key)}\s*=\s*"([^"]+)"\s*$', section_match.group("body")
+    )
+    assert value_match, f"{section}.{key}"
+    return value_match.group(1)
+
+
 def test_codemeta_matches_release_metadata():
     codemeta = json.loads((ROOT / "codemeta.json").read_text())
-    project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+    pyproject = (ROOT / "pyproject.toml").read_text()
 
-    distribution = project["name"]
-    repository = project["urls"]["Repository"]
-    version = project["version"]
+    distribution = _toml_string(pyproject, "project", "name")
+    repository = _toml_string(pyproject, "project.urls", "Repository")
+    issues = _toml_string(pyproject, "project.urls", "Issues")
+    version = _toml_string(pyproject, "project", "version")
 
     assert codemeta["@context"] == "https://w3id.org/codemeta/3.1"
     assert codemeta["@type"] == "SoftwareSourceCode"
@@ -23,7 +36,7 @@ def test_codemeta_matches_release_metadata():
     assert codemeta["version"] == version
     assert codemeta["codeRepository"] == repository
     assert codemeta["url"] == repository
-    assert codemeta["issueTracker"] == project["urls"]["Issues"]
+    assert codemeta["issueTracker"] == issues
     assert codemeta["downloadUrl"] == (
         f"https://pypi.org/project/{distribution}/{version}/"
     )

--- a/tests/test_codemeta.py
+++ b/tests/test_codemeta.py
@@ -1,0 +1,30 @@
+"""Keep CodeMeta synchronized with the tracked release metadata."""
+
+import json
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_codemeta_matches_release_metadata():
+    codemeta = json.loads((ROOT / "codemeta.json").read_text())
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+
+    distribution = project["name"]
+    repository = project["urls"]["Repository"]
+    version = project["version"]
+
+    assert codemeta["@context"] == "https://w3id.org/codemeta/3.1"
+    assert codemeta["@type"] == "SoftwareSourceCode"
+    assert codemeta["name"] == "fidelis"
+    assert distribution == "fidelis-memory"
+    assert codemeta["version"] == version
+    assert codemeta["codeRepository"] == repository
+    assert codemeta["url"] == repository
+    assert codemeta["issueTracker"] == project["urls"]["Issues"]
+    assert codemeta["downloadUrl"] == (
+        f"https://pypi.org/project/{distribution}/{version}/"
+    )
+    assert codemeta["releaseNotes"] == f"{repository}/releases/tag/v{version}"

--- a/tests/test_codemeta.py
+++ b/tests/test_codemeta.py
@@ -6,38 +6,69 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+DOI = "https://doi.org/10.5281/zenodo.21873318"
+ORCID = "https://orcid.org/0009-0005-4896-1112"
+VOLATILE_DATE_KEYS = {"dateCreated", "dateModified", "datePublished"}
 
 
-def _toml_string(text, section, key):
+def _toml_section(text, section):
     section_match = re.search(
         rf"(?ms)^\[{re.escape(section)}\]\n(?P<body>.*?)(?=^\[|\Z)", text
     )
     assert section_match, section
+    return section_match.group("body")
+
+
+def _toml_string(text, section, key):
     value_match = re.search(
-        rf'(?m)^{re.escape(key)}\s*=\s*"([^"]+)"\s*$', section_match.group("body")
+        rf'(?m)^{re.escape(key)}\s*=\s*"([^"]+)"\s*$', _toml_section(text, section)
     )
     assert value_match, f"{section}.{key}"
+    return value_match.group(1)
+
+
+def _toml_inline_string(text, section, key, nested_key):
+    table_match = re.search(
+        rf"(?m)^{re.escape(key)}\s*=\s*\{{(?P<table>[^}}\n]+)\}}\s*$",
+        _toml_section(text, section),
+    )
+    assert table_match, f"{section}.{key}"
+    value_match = re.search(
+        rf'\b{re.escape(nested_key)}\s*=\s*"([^"]+)"', table_match.group("table")
+    )
+    assert value_match, f"{section}.{key}.{nested_key}"
     return value_match.group(1)
 
 
 def test_codemeta_matches_release_metadata():
     codemeta = json.loads((ROOT / "codemeta.json").read_text())
     pyproject = (ROOT / "pyproject.toml").read_text()
+    citation = (ROOT / "CITATION.cff").read_text()
 
     distribution = _toml_string(pyproject, "project", "name")
+    license_name = _toml_inline_string(pyproject, "project", "license", "text")
     repository = _toml_string(pyproject, "project.urls", "Repository")
     issues = _toml_string(pyproject, "project.urls", "Issues")
+    requires_python = _toml_string(pyproject, "project", "requires-python")
     version = _toml_string(pyproject, "project", "version")
 
     assert codemeta["@context"] == "https://w3id.org/codemeta/3.1"
     assert codemeta["@type"] == "SoftwareSourceCode"
     assert codemeta["name"] == "fidelis"
     assert distribution == "fidelis-memory"
+    assert distribution in codemeta["description"]
     assert codemeta["version"] == version
     assert codemeta["codeRepository"] == repository
     assert codemeta["url"] == repository
     assert codemeta["issueTracker"] == issues
+    assert codemeta["license"] == f"https://spdx.org/licenses/{license_name}"
+    assert codemeta["runtimePlatform"] == f"Python {requires_python}"
     assert codemeta["downloadUrl"] == (
         f"https://pypi.org/project/{distribution}/{version}/"
     )
     assert codemeta["releaseNotes"] == f"{repository}/releases/tag/v{version}"
+    assert codemeta["identifier"] == DOI
+    assert codemeta["author"][0]["@id"] == ORCID
+    assert f'orcid: "{ORCID}"' in citation
+    assert "applicationCategory" not in codemeta
+    assert VOLATILE_DATE_KEYS.isdisjoint(codemeta)


### PR DESCRIPTION
## Summary

- add a CodeMeta 3.1 record for the `fidelis` source project
- distinguish the source/import/CLI name from the `fidelis-memory` PyPI distribution
- include the verified v0.0.93 Zenodo software DOI, canonical repository, MIT license, ORCID, and versioned release links
- add a deterministic consistency test tying CodeMeta to `pyproject.toml` release metadata

## Impact

Metadata and test coverage only; no runtime behavior or package dependencies change. The record omits volatile `dateModified` metadata.

## Validation

- `ruff check src/ tests/`
- hermetic CI suite: 369 passed, 3 skipped
- official CodeMeta Generator validator: PASS
- JSON-LD expansion against the live `https://w3id.org/codemeta/3.1` context: PASS
- live URL readback: repository, versioned PyPI page, MIT license, GitHub release, DOI, and ORCID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized CodeMeta metadata describing the software project, release, licensing, supported platforms, runtime, and scholarly references.

* **Tests**
  * Added validation to ensure project metadata stays consistent across release, repository, citation, licensing, and identification details.
  * Added checks for required CodeMeta fields and protection against volatile metadata values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->