### PR TITLE
docs(llms.txt): align retrieval headline with README and runP-v35 evidence

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,5 +1,5 @@
 # fidelis
-> Zero-LLM memory for AI agents and Claude Code. Integer-pointer fidelity guarantee — original passages returned verbatim, never paraphrased. 73.0% end-to-end QA on LongMemEval-S (470 questions, 2026-04-24); 96.4% R@1 retrieval (runP-v35, 2026-04-18). Local, $0/query, fully private. By Hermes Labs. (Internal codename during development: cogito-ergo.)
+> Zero-LLM memory for AI agents and Claude Code. Integer-pointer fidelity guarantee — original passages returned verbatim, never paraphrased. 73.0% end-to-end QA on LongMemEval-S (470 questions, 2026-04-24); 83.2% R@1 zero-LLM retrieval (runP-v35 stage 1, 2026-04-18). Local, $0/query, fully private. By Hermes Labs. (Internal codename during development: cogito-ergo.)
 
 ## What it is
 
@@ -19,9 +19,9 @@ Fidelity guarantee: when the optional filter tier is enabled, the filter LLM out
 
 ### LongMemEval-S retrieval (470 questions, runP-v35, 2026-04-18) — /recall_hybrid
 
-- R@1=96.4%, R@3=98.1%, R@5=98.3%, R@10=99.1%
-- Avg latency: 165ms retrieval + 1436ms filter (filter tier opt-in)
-- Architecture: BM25+dense+RRF → temporal boost → runtime escalation → qwen-turbo filter
+- Zero-LLM stage 1 (default path): R@1=83.2%, R@3=95.1%, R@5=98.3%, R@10=99.1% (`stage1_metrics.recall_any` in bench/runs/runP-v35/aggregate.json)
+- Avg latency in that run: 165 ms retrieval; the opt-in LLM filter tier adds ~1436 ms and its own recall figures are recorded under `stage2_metrics` in the same file (not a headline claim)
+- Architecture: BM25+dense+RRF → temporal boost → runtime escalation → optional qwen-turbo filter
 
 ### 31-case atomic eval (2026-03-28) — /recall
 

--- a/tests/test_public_install_truth.py
+++ b/tests/test_public_install_truth.py
@@ -41,6 +41,21 @@ def test_current_readme_links_shipped_benchmark_receipts():
     assert recall["R@5"] == 0.983
 
 
+def test_llms_txt_headline_matches_readme_retrieval_claim():
+    """llms.txt is the agent-facing summary; its headline R@1 must be the same
+    zero-LLM stage-1 figure the README and aggregate.json carry, never the
+    opt-in LLM-filter (stage 2) figure presented as the default-path result."""
+    llms = (ROOT / "llms.txt").read_text()
+    headline = llms.splitlines()[1]
+    retrieval = ROOT / "bench" / "runs" / "runP-v35" / "aggregate.json"
+    stage1 = json.loads(retrieval.read_text())["stage1_metrics"]["recall_any"]
+    expected = f"{stage1['R@1'] * 100:.1f}% R@1"
+    assert expected in headline, headline
+    assert "zero-LLM" in headline, headline
+    assert "96.4% R@1" not in headline, headline
+    assert "bench/runs/runP-v35/aggregate.json" in llms
+
+
 def test_readme_scopes_no_telemetry_claim_to_documented_defaults():
     readme = (ROOT / "README.md").read_text()
     assert "no outbound network calls" not in readme


### PR DESCRIPTION
## What

- `llms.txt` headline: `96.4% R@1 retrieval (runP-v35)` → `83.2% R@1 zero-LLM retrieval (runP-v35 stage 1)`.
- `llms.txt` retrieval section: lists the stage-1 (default, zero-LLM) recall figures from `bench/runs/runP-v35/aggregate.json` (`stage1_metrics.recall_any`: R@1 0.832, R@3 0.951, R@5 0.983, R@10 0.991) and notes that the opt-in filter tier's figures live under `stage2_metrics` in the same file.
- `tests/test_public_install_truth.py`: new test binds the `llms.txt` headline to the same `aggregate.json` figure the README test already enforces.

## Why

`README.md` leads with 83.2% R@1 and "no LLM in the default retrieval path"; `llms.txt` led with the opt-in LLM-filter figure as if it were the default-path result. `docs/RELEASE-SCOPE.md` already says "No 96.4% headline". The tier-scoped mentions in `docs/full-reference.md` and `agents.md` are unchanged.

## Validation

- `python3 -m pytest -q tests/test_public_install_truth.py tests/test_codemeta.py` → 6 passed
- external-framing-lint on `llms.txt` → exit 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark claims in `llms.txt` to distinguish zero-LLM stage-1 retrieval results from opt-in filtering and stage-2 metrics.
  * Corrected the headline retrieval result to 83.2% R@1 and added clearer benchmark references.

* **Tests**
  * Added validation ensuring the headline matches the README and benchmark data, includes the zero-LLM designation, and avoids presenting the opt-in result as the headline metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->