### PR TITLE
feat: add Codex MCP installation and context orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fidelis Memory
 
-## Local-first, zero-LLM memory for Claude Code and AI agents.
+## Local-first, zero-LLM memory for Codex, Claude Code, and AI agents.
 
 **73.0% end-to-end QA on LongMemEval-S. 83.2% R@1 retrieval. $0/query. No LLM in the default retrieval path.**
 
@@ -20,7 +20,7 @@ fidelis retrieval       (BM25 + dense + RRF, no LLM)
        ↓
 original passages       (verbatim, never rephrased)
        ↓
-Claude Code / your agent
+Codex / Claude Code / your agent
 ```
 
 What fidelis is:
@@ -30,7 +30,7 @@ What fidelis is:
 - **private** - local memory store by default
 - **faithful** - original stored passages returned, not paraphrases
 - **proven** - benchmarked on LongMemEval-S (470 questions, public benchmark), with raw evidence in [`experiments/zeroLLM-FLAGSHIP-evidence/`](experiments/zeroLLM-FLAGSHIP-evidence/)
-- **installable** - Claude Code via MCP in about 60 seconds
+- **installable** - Codex or Claude Code via MCP in about 60 seconds
 
 ---
 
@@ -45,8 +45,8 @@ ollama pull nomic-embed-text
 python3 -m pip install "fidelis-memory==0.0.93"
 fidelis init                  # background service (launchd / systemd)
 fidelis watch ~/notes         # auto-ingests markdown
-fidelis mcp install           # wires Claude Code
-# Restart Claude Code. Memory is on.
+fidelis mcp install --client codex   # or omit --client for Claude Code
+# Restart your agent client. Memory is on.
 ```
 
 > **Package-name note:** install Hermes Labs' package as `fidelis-memory`.
@@ -59,7 +59,7 @@ v0.0.93 - first PyPI release of `fidelis-memory`.
 
 ## What you notice immediately
 
-After the four commands above, the next time you open Claude Code:
+After the four commands above, the next time you open Codex or Claude Code:
 
 - It stops asking you to repeat context you already wrote down.
 - You can ask "what did we decide last week about auth?" - and the answer cites your actual decision, not a generic OAuth lecture.
@@ -95,16 +95,16 @@ The 3600s window is non-configurable in our current contract.
 
 The non-configurable qualifier survives. So does every other detail you wrote down.
 
-## What this enables in Claude Code
+## What this enables in Codex and Claude Code
 
-Once `fidelis mcp install` is run, ask your agent:
+Once `fidelis mcp install --client codex` (or the default Claude install) is run, ask your agent:
 
 - *"What did we decide about auth?"*
 - *"What failed last time we tried this migration?"*
 - *"Which billing constraint was non-configurable?"*
 - *"What did I say about Sarah's onboarding flow?"*
 
-The MCP `fidelis_recall` tool fires before Claude composes its answer. Claude sees the original passages, not paraphrased summaries. The answer is grounded in what you wrote, with the qualifiers intact.
+The MCP `fidelis_recall` tool gives the agent the original passages before it composes an answer, not paraphrased summaries. The answer can stay grounded in what you wrote, with the qualifiers intact.
 
 > **fidelis retrieves memory without an LLM. Your agent still uses its normal LLM to answer using the retrieved context.** "Zero-LLM" applies to the memory hot path, not to your agent.
 
@@ -118,7 +118,7 @@ Three concrete reasons teams pick fidelis over hosted memory:
 
 ## How it fits
 
-The diagram is at the top. Claude Code is the fastest path to value. The retrieval engine is agent-agnostic - pair it with any LLM client.
+The diagram is at the top. Codex and Claude Code are the fastest paths to value. The retrieval engine is agent-agnostic - pair it with any LLM client. Codex registration uses its supported `codex mcp` CLI, and the resulting server configuration is shared by the Codex desktop app, CLI, and IDE extension on that host.
 
 ## Benchmarks
 
@@ -216,7 +216,7 @@ After `fidelis init`:
 
 - **Service:** `fidelis-server` runs at `http://127.0.0.1:19420` under your OS service manager (launchd on macOS, systemd on Linux). Auto-starts on boot. Logs at `~/.fidelis/server.log`.
 - **Storage:** Chroma + SQLite at `~/.cogito/` (the directory name is preserved from the project's pre-rename codename for v0.0.x compatibility - it will move to `~/.fidelis/` in a later major bump). No data leaves your machine in the default zero-LLM path.
-- **MCP:** if you ran `fidelis mcp install`, Claude Code sees three tools: `fidelis_recall`, `fidelis_query`, `fidelis_health`.
+- **MCP:** after installing for your selected client, Codex or Claude Code sees three tools: `fidelis_recall`, `fidelis_query`, `fidelis_health`.
 
 To stop: `fidelis init --uninstall`. To wipe: `rm -rf ~/.cogito ~/.fidelis`.
 
@@ -237,7 +237,7 @@ To stop: `fidelis init --uninstall`. To wipe: `rm -rf ~/.cogito ~/.fidelis`.
 ## What this turns into over time
 
 Day 1: drop notes into `~/notes`, run the four commands.
-Day 2: ask Claude Code about yesterday's decision - the answer cites your original passage.
+Day 2: ask your agent about yesterday's decision - the answer cites your original passage.
 Day 7: your agent starts carrying project context across sessions; you stop re-explaining.
 
 Useful for solo builders today; relevant for teams that need memory to stay local tomorrow.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ tail ~/.fidelis/server.log
 
 The default `zero_llm` tier never makes an outbound LLM call. Optional `--tier filter` and `--tier flagship` modes do call an LLM, but only to select integer pointers - the server dereferences those pointers to the original stored text. The LLM cannot rephrase memory content.
 
+### Context-sensitive orientation (MCP)
+
+The bundled MCP server also exposes `fidelis_orient`. It recognizes when a
+turn invokes prior work—even when it is a statement such as “I need to
+remember our Fidelis work”—and selects a bounded evidence lane for identity,
+maintenance, conceptual reuse, comparison, decisions, historical state, or
+current state. The returned orientation is a derived index; retrieved records
+remain verbatim evidence with their existing IDs and metadata. Unrelated turns
+explicitly abstain without calling the memory server.
+
 ## Requirements
 
 - macOS or Linux (Windows not yet supported)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ After `fidelis init`:
 
 - **Service:** `fidelis-server` runs at `http://127.0.0.1:19420` under your OS service manager (launchd on macOS, systemd on Linux). Auto-starts on boot. Logs at `~/.fidelis/server.log`.
 - **Storage:** Chroma + SQLite at `~/.cogito/` (the directory name is preserved from the project's pre-rename codename for v0.0.x compatibility - it will move to `~/.fidelis/` in a later major bump). No data leaves your machine in the default zero-LLM path.
-- **MCP:** after installing for your selected client, Codex or Claude Code sees three tools: `fidelis_recall`, `fidelis_query`, `fidelis_health`.
+- **MCP:** after installing for your selected client, Codex or Claude Code sees four tools: `fidelis_recall`, `fidelis_query`, `fidelis_health`, and `fidelis_orient`.
 
 To stop: `fidelis init --uninstall`. To wipe: `rm -rf ~/.cogito ~/.fidelis`.
 

--- a/agents.md
+++ b/agents.md
@@ -154,7 +154,8 @@ If the upstream LLM (Ollama / extraction model) is unreachable, `/store` and `/a
 2. `fidelis calibrate` — build vocab bridge from corpus (one-time)
 3. `fidelis snapshot` — build compressed index (one-time, rebuild after major changes)
 4. `fidelis init` — install background service (launchd / systemd)
-5. `fidelis mcp install` — wire Claude Code as an MCP client
+5. `fidelis mcp install --client codex` — wire Codex as an MCP client, or
+   `fidelis mcp install` for Claude Code
 
 If extraction is broken (zer0lint score < 80%), fix that before deploying fidelis. No point filtering garbage.
 

--- a/src/fidelis/cli.py
+++ b/src/fidelis/cli.py
@@ -3,7 +3,7 @@ fidelis CLI
 
   fidelis init                       install + start service (launchd/systemd)
   fidelis watch  ~/notes             auto-ingest a directory
-  fidelis mcp install                wire Claude Code MCP integration
+  fidelis mcp install --client codex wire Codex MCP integration
   fidelis recall "query"             two-stage recall via running server
   fidelis query  "query"             simple vector query (no filter)
   fidelis add    "text"              add a memory
@@ -310,15 +310,19 @@ def main():
     p_watch.add_argument("--verbose", "-v", action="store_true")
     p_watch.set_defaults(func=lambda a: sys.exit(_cmd_watch(a)))
 
-    # mcp — manage Claude Code MCP integration
-    p_mcp = sub.add_parser("mcp", help="Manage Claude Code MCP integration")
+    # mcp — manage agent-client MCP integration
+    p_mcp = sub.add_parser("mcp", help="Manage Claude Code or Codex MCP integration")
     mcp_sub = p_mcp.add_subparsers(dest="mcp_command", required=True)
-    p_mcp_install = mcp_sub.add_parser("install", help="Install fidelis MCP server into ~/.claude/settings.local.json")
+    p_mcp_install = mcp_sub.add_parser("install", help="Install the fidelis MCP server into an agent client")
+    p_mcp_install.add_argument("--client", choices=("claude", "codex"), default="claude",
+                               help="MCP client to configure (default: claude)")
     p_mcp_install.add_argument("--settings", help="Path to settings.local.json (default: ~/.claude/settings.local.json)")
     p_mcp_install.add_argument("--force", action="store_true",
                                help="Overwrite an existing 'fidelis' entry even if it doesn't look like ours")
     p_mcp_install.set_defaults(func=lambda a: sys.exit(_cmd_mcp_install(a)))
-    p_mcp_uninstall = mcp_sub.add_parser("uninstall", help="Remove fidelis MCP server from settings")
+    p_mcp_uninstall = mcp_sub.add_parser("uninstall", help="Remove the fidelis MCP server from an agent client")
+    p_mcp_uninstall.add_argument("--client", choices=("claude", "codex"), default="claude",
+                                 help="MCP client to configure (default: claude)")
     p_mcp_uninstall.add_argument("--settings", help="Path to settings.local.json")
     p_mcp_uninstall.set_defaults(func=lambda a: sys.exit(_cmd_mcp_uninstall(a)))
 

--- a/src/fidelis/context.py
+++ b/src/fidelis/context.py
@@ -77,11 +77,33 @@ class ContextPlan:
 
 def _entity_from_turns(utterance: str, recent_turns: Iterable[str]) -> str | None:
     combined = [utterance, *list(recent_turns)[-4:]]
-    for text in combined:
+    for index, text in enumerate(combined):
         lowered = text.casefold()
         for entity in _KNOWN_ENTITIES:
             if entity.casefold() in lowered:
                 return entity
+        # Capitalization alone is not evidence that a turn names prior work:
+        # sentence starters such as "Can", "Please", and "How" otherwise
+        # become false project entities.  Infer an unknown proper noun only
+        # from recent context or when the current turn itself asks for
+        # identity/history/current-state context.  Callers can always provide
+        # ``entity_hint`` for a new project name.
+        allow_unknown = index > 0 or any(
+            pattern.search(text)
+            for pattern in (
+                _RECALL_RE,
+                _PAST_WORK_RE,
+                _TRANSFER_RE,
+                _COMPARISON_RE,
+                _DECISION_RE,
+                _HISTORICAL_RE,
+                _CURRENT_RE,
+                _IDENTITY_RE,
+                _CASUAL_RE,
+            )
+        )
+        if not allow_unknown:
+            continue
         candidates = [
             item
             for item in _ENTITY_RE.findall(text)
@@ -100,6 +122,17 @@ def _entity_from_turns(utterance: str, recent_turns: Iterable[str]) -> str | Non
                 "explain",
                 "review",
                 "summarize",
+                "can",
+                "how",
+                "please",
+                "tell",
+                "this",
+                "that",
+                "the",
+                "we",
+                "our",
+                "my",
+                "i",
             }
         ]
         if candidates:

--- a/src/fidelis/context.py
+++ b/src/fidelis/context.py
@@ -1,0 +1,195 @@
+"""Deterministic, evidence-bound context planning for agent turns.
+
+The planner answers a narrower question than retrieval: does this utterance
+need historical context, and which evidence lane should be searched?  It does
+not summarize memories or create truth.  Callers keep the returned records
+verbatim and may use the plan as an orientation card for an agent.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable
+
+
+_KNOWN_ENTITIES = ("Fidelis", "Cogito", "Hermes", "Hercules", "RoliTwin")
+_ENTITY_RE = re.compile(r"\b[A-Z][A-Za-z0-9_.-]{2,}\b")
+_RECALL_RE = re.compile(
+    r"\b(?:remember|recall|catch (?:me )?up|where did we leave|"
+    r"previous (?:work|chat|task)|earlier (?:work|chat|task)|"
+    r"from (?:a few|several|two|three) (?:days|weeks|months) ago)\b",
+    re.IGNORECASE,
+)
+_PAST_WORK_RE = re.compile(
+    r"\b(?:our|my|we)\b.*\b(?:project|repo(?:sitory)?|work|decision|"
+    r"release|implementation|experiment|system|chat|task)\b",
+    re.IGNORECASE,
+)
+_MAINTENANCE_RE = re.compile(
+    r"\b(?:fix|debug|maintain|implement|integrat|test|deploy|ship|repo|"
+    r"code|bug|issue|dependency|installer)\w*\b",
+    re.IGNORECASE,
+)
+_TRANSFER_RE = re.compile(
+    r"\b(?:apply|adapt|reuse|transfer|help with|use .* for|could .* help)\b",
+    re.IGNORECASE,
+)
+_COMPARISON_RE = re.compile(
+    r"\b(?:compare|different from|versus|vs\.?|relationship between)\b",
+    re.IGNORECASE,
+)
+_DECISION_RE = re.compile(
+    r"\b(?:why did we|why we|decision|rationale|decid\w*|chos\w*|chose)\b",
+    re.IGNORECASE,
+)
+_HISTORICAL_RE = re.compile(
+    r"\b(?:originally|at the time|back then|histor\w*|timeline|months? ago|"
+    r"weeks? ago|days? ago|previously|earlier)\b",
+    re.IGNORECASE,
+)
+_CURRENT_RE = re.compile(
+    r"\b(?:current(?:ly)?|latest|now|today|status|where (?:is|are) .* now)\b",
+    re.IGNORECASE,
+)
+_IDENTITY_RE = re.compile(r"^\s*(?:what|who)\s+(?:is|was|are)\b", re.IGNORECASE)
+_CASUAL_RE = re.compile(
+    r"\b(?:weird|funny|good|bad|interesting|strange)\b[^?]*[.!]?\s*$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ContextPlan:
+    """Closed plan for one context-sensitive retrieval decision."""
+
+    schema: str
+    disposition: str
+    entity: str | None
+    conversational_role: str
+    evidence_lane: str | None
+    retrieval_query: str | None
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _entity_from_turns(utterance: str, recent_turns: Iterable[str]) -> str | None:
+    combined = [utterance, *list(recent_turns)[-4:]]
+    for text in combined:
+        lowered = text.casefold()
+        for entity in _KNOWN_ENTITIES:
+            if entity.casefold() in lowered:
+                return entity
+        candidates = [
+            item
+            for item in _ENTITY_RE.findall(text)
+            if item.casefold()
+            not in {
+                "what",
+                "where",
+                "when",
+                "why",
+                "could",
+                "should",
+                "write",
+                "draft",
+                "create",
+                "build",
+                "explain",
+                "review",
+                "summarize",
+            }
+        ]
+        if candidates:
+            return candidates[0]
+    return None
+
+
+def _query(entity: str | None, lane: str, utterance: str) -> str:
+    subject = entity or utterance.strip()
+    suffixes = {
+        "identity": "identity purpose aliases orientation",
+        "maintenance": "repository implementation status tests issues decisions",
+        "conceptual": "purpose conceptual rationale design possible reuse",
+        "comparison": "comparison relationship differences decisions",
+        "decision": "decision rationale reason evidence",
+        "historical": "historical state timeline original intent",
+        "current": "current state latest supported decision status",
+        "context": "prior work context decisions current state",
+    }
+    return f"{subject} {suffixes[lane]}".strip()
+
+
+def plan_context(
+    utterance: str,
+    *,
+    recent_turns: Iterable[str] = (),
+    entity_hint: str | None = None,
+) -> ContextPlan:
+    """Classify an utterance, including non-questions, into one evidence lane."""
+
+    local = utterance.strip()
+    recent = tuple(recent_turns)[-4:]
+    entity = entity_hint.strip() if entity_hint and entity_hint.strip() else None
+    entity = entity or _entity_from_turns(local, recent)
+    source_bound = bool(entity or _RECALL_RE.search(local) or _PAST_WORK_RE.search(local))
+
+    if not local:
+        role, lane, reason = "no_memory_needed", None, "empty utterance"
+    elif not source_bound:
+        role, lane, reason = (
+            "no_memory_needed",
+            None,
+            "no known referent or historical-context cue",
+        )
+    elif _COMPARISON_RE.search(local):
+        role, lane, reason = "comparative_context", "comparison", "comparison cue"
+    elif _MAINTENANCE_RE.search(local):
+        role, lane, reason = "maintenance_context", "maintenance", "maintenance cue"
+    elif _TRANSFER_RE.search(local):
+        role, lane, reason = "conceptual_transfer", "conceptual", "reuse cue"
+    elif _DECISION_RE.search(local):
+        role, lane, reason = "decision_context", "decision", "decision cue"
+    elif _HISTORICAL_RE.search(local):
+        role, lane, reason = "historical_recall", "historical", "historical cue"
+    elif _CURRENT_RE.search(local):
+        role, lane, reason = "context_refresh", "current", "current-state cue"
+    elif _IDENTITY_RE.search(local) or (entity and _CASUAL_RE.search(local)):
+        role, lane, reason = "identity_only", "identity", "orientation is sufficient"
+    else:
+        role, lane, reason = "context_refresh", "context", "historical context requested"
+
+    disposition = "abstain" if lane is None else "retrieve"
+    return ContextPlan(
+        schema="fidelis-context-plan/v1",
+        disposition=disposition,
+        entity=entity,
+        conversational_role=role,
+        evidence_lane=lane,
+        retrieval_query=_query(entity, lane, local) if lane else None,
+        reason=reason,
+    )
+
+
+def context_packet(plan: ContextPlan, records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Bind a plan to unmodified evidence records; never synthesize a summary."""
+
+    selected = []
+    for index, record in enumerate(records):
+        item = dict(record)
+        item.setdefault("record_id", item.get("id") or f"result-{index + 1}")
+        selected.append(item)
+    return {
+        "schema": "fidelis-context-packet/v1",
+        "orientation": {
+            "entity": plan.entity,
+            "conversational_role": plan.conversational_role,
+            "evidence_lane": plan.evidence_lane,
+            "authority": "derived index; records remain verbatim evidence",
+        },
+        "plan": plan.to_dict(),
+        "records": selected,
+        "evidence_status": "available" if selected else "insufficient",
+    }

--- a/src/fidelis/context.py
+++ b/src/fidelis/context.py
@@ -99,7 +99,6 @@ def _entity_from_turns(utterance: str, recent_turns: Iterable[str]) -> str | Non
                 _HISTORICAL_RE,
                 _CURRENT_RE,
                 _IDENTITY_RE,
-                _CASUAL_RE,
             )
         )
         if not allow_unknown:

--- a/src/fidelis/mcp_cmd.py
+++ b/src/fidelis/mcp_cmd.py
@@ -39,8 +39,11 @@ def _is_fidelis_codex_entry(entry: dict) -> bool:
     transport = entry.get("transport", entry)
     command = str(transport.get("command", ""))
     args = [str(value) for value in transport.get("args", [])]
-    blob = " ".join([command, *args])
-    return "fidelis" in blob or "mcp_server.py" in blob
+    return (
+        Path(command).expanduser().resolve() == Path(sys.executable).resolve()
+        and len(args) == 1
+        and Path(args[0]).expanduser().resolve() == MCP_SERVER_FILE.resolve()
+    )
 
 
 def _codex_cli() -> str | None:

--- a/src/fidelis/mcp_cmd.py
+++ b/src/fidelis/mcp_cmd.py
@@ -1,8 +1,8 @@
-"""fidelis mcp install — wire fidelis into Claude Code's MCP config.
+"""Wire fidelis into a supported agent client's MCP configuration.
 
-Writes a fidelis MCP server entry into ~/.claude/settings.local.json. Idempotent;
-backs up existing settings first; refuses to overwrite if a non-fidelis entry
-named "fidelis" already exists.
+Claude Code configuration is edited atomically with a backup. Codex
+configuration is delegated to the supported ``codex mcp`` CLI so the desktop
+app, CLI, and IDE extension share the same registered server.
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -33,7 +34,119 @@ PACKAGE_DIR = Path(__file__).resolve().parent
 MCP_SERVER_FILE = PACKAGE_DIR / "mcp_server.py"
 
 
+def _is_fidelis_codex_entry(entry: dict) -> bool:
+    """Return whether a Codex MCP entry launches this packaged server."""
+    transport = entry.get("transport", entry)
+    command = str(transport.get("command", ""))
+    args = [str(value) for value in transport.get("args", [])]
+    blob = " ".join([command, *args])
+    return "fidelis" in blob or "mcp_server.py" in blob
+
+
+def _codex_cli() -> str | None:
+    return shutil.which("codex")
+
+
+def _codex_get(codex_bin: str) -> tuple[int, dict | None, str]:
+    result = subprocess.run(
+        [codex_bin, "mcp", "get", MCP_SERVER_NAME, "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return result.returncode, None, result.stderr.strip()
+    try:
+        return 0, json.loads(result.stdout), ""
+    except json.JSONDecodeError as exc:
+        return 1, None, f"Codex returned invalid JSON for '{MCP_SERVER_NAME}': {exc}"
+
+
+def _cmd_codex_install(args) -> int:
+    if getattr(args, "settings", None):
+        print(
+            "error: --settings is only supported for the Claude Code client; "
+            "Codex uses its shared config through the codex mcp CLI",
+            file=sys.stderr,
+        )
+        return 1
+    codex_bin = _codex_cli()
+    if not codex_bin:
+        print(
+            "error: Codex CLI not found on PATH\n"
+            "  install Codex, then rerun: fidelis mcp install --client codex",
+            file=sys.stderr,
+        )
+        return 1
+
+    rc, existing, error = _codex_get(codex_bin)
+    if existing is not None:
+        if _is_fidelis_codex_entry(existing):
+            print("Codex MCP server 'fidelis' is already configured; nothing to change")
+            return 0
+        if not args.force:
+            print(
+                "error: a non-fidelis Codex MCP server named 'fidelis' already exists\n"
+                "  refusing to overwrite. Use --force to replace it.",
+                file=sys.stderr,
+            )
+            return 1
+        # Let the supported Codex CLI replace the entry atomically. Do not
+        # remove first: if registration fails, the user's prior entry remains.
+    elif rc != 0 and "No MCP server named" not in error:
+        print(error or "error: could not inspect Codex MCP configuration", file=sys.stderr)
+        return rc
+
+    result = subprocess.run(
+        [codex_bin, "mcp", "add", MCP_SERVER_NAME, "--", sys.executable, str(MCP_SERVER_FILE)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip() or "error: Codex MCP registration failed", file=sys.stderr)
+        return result.returncode
+
+    print(result.stdout.strip() or "registered Codex MCP server 'fidelis'")
+    print("next: restart Codex, then use /mcp to confirm the fidelis tools")
+    return 0
+
+
+def _cmd_codex_uninstall() -> int:
+    codex_bin = _codex_cli()
+    if not codex_bin:
+        print("error: Codex CLI not found on PATH", file=sys.stderr)
+        return 1
+    rc, existing, error = _codex_get(codex_bin)
+    if existing is None:
+        if rc != 0 and "No MCP server named" not in error:
+            print(error or "error: could not inspect Codex MCP configuration", file=sys.stderr)
+            return rc
+        print("no 'fidelis' MCP server registered in Codex; nothing to uninstall")
+        return 0
+    if not _is_fidelis_codex_entry(existing):
+        print(
+            "error: Codex MCP server 'fidelis' does not appear to belong to Fidelis; refusing to remove it",
+            file=sys.stderr,
+        )
+        return 1
+    result = subprocess.run(
+        [codex_bin, "mcp", "remove", MCP_SERVER_NAME],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip() or "error: Codex MCP removal failed", file=sys.stderr)
+        return result.returncode
+    print(result.stdout.strip() or "removed Codex MCP server 'fidelis'")
+    return 0
+
+
 def cmd_mcp_install(args) -> int:
+    if getattr(args, "client", "claude") == "codex":
+        return _cmd_codex_install(args)
+
     settings_path = Path(args.settings).expanduser() if args.settings else DEFAULT_SETTINGS
 
     if not MCP_SERVER_FILE.exists():
@@ -95,6 +208,16 @@ def cmd_mcp_install(args) -> int:
 
 
 def cmd_mcp_uninstall(args) -> int:
+    if getattr(args, "client", "claude") == "codex":
+        if getattr(args, "settings", None):
+            print(
+                "error: --settings is only supported for the Claude Code client; "
+                "Codex uses its shared config through the codex mcp CLI",
+                file=sys.stderr,
+            )
+            return 1
+        return _cmd_codex_uninstall()
+
     settings_path = Path(args.settings).expanduser() if args.settings else DEFAULT_SETTINGS
 
     if not settings_path.exists():

--- a/src/fidelis/mcp_server.py
+++ b/src/fidelis/mcp_server.py
@@ -13,6 +13,7 @@ import urllib.error
 import urllib.request
 
 from fidelis import __version__
+from fidelis.context import context_packet, plan_context
 
 
 def _server_url() -> str:
@@ -76,6 +77,32 @@ TOOLS = [
         "description": "Check the fidelis server's health and memory count.",
         "inputSchema": {"type": "object", "properties": {}},
     },
+    {
+        "name": "fidelis_orient",
+        "description": (
+            "Context-sensitive re-entry for prior work. Call when a turn mentions "
+            "a known project, decision, earlier work, maintenance, comparison, or "
+            "possible reuse—even when the turn is not phrased as a question. "
+            "Returns an evidence-bound orientation packet or explicitly abstains."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "utterance": {"type": "string", "description": "Current user turn"},
+                "recent_turns": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Up to four recent turns for referent resolution",
+                },
+                "entity": {
+                    "type": "string",
+                    "description": "Optional exact known project or concept name",
+                },
+                "limit": {"type": "integer", "default": 5},
+            },
+            "required": ["utterance"],
+        },
+    },
 ]
 
 
@@ -124,10 +151,39 @@ def _tool_health(arguments: dict) -> str:
     )
 
 
+def _tool_orient(arguments: dict) -> str:
+    utterance = str(arguments.get("utterance", ""))
+    recent_turns = arguments.get("recent_turns", [])
+    if not isinstance(recent_turns, list):
+        recent_turns = []
+    plan = plan_context(
+        utterance,
+        recent_turns=[str(turn) for turn in recent_turns[-4:]],
+        entity_hint=arguments.get("entity"),
+    )
+    if plan.disposition == "abstain":
+        return json.dumps(context_packet(plan, []), ensure_ascii=False)
+    limit = max(1, min(int(arguments.get("limit", 5)), 20))
+    res = _http_post(
+        "/recall_hybrid",
+        {"text": plan.retrieval_query, "limit": limit, "tier": "zero_llm"},
+    )
+    if res.get("error"):
+        packet = context_packet(plan, [])
+        packet["evidence_status"] = "unavailable"
+        packet["error"] = res["error"]
+        return json.dumps(packet, ensure_ascii=False)
+    return json.dumps(
+        context_packet(plan, res.get("memories", [])[:limit]),
+        ensure_ascii=False,
+    )
+
+
 TOOL_HANDLERS = {
     "fidelis_recall": _tool_recall,
     "fidelis_query": _tool_query,
     "fidelis_health": _tool_health,
+    "fidelis_orient": _tool_orient,
 }
 
 

--- a/src/fidelis/mcp_server.py
+++ b/src/fidelis/mcp_server.py
@@ -1,6 +1,6 @@
 """Minimal MCP server bundled with fidelis — exposes recall + health as MCP tools.
 
-Implements the JSON-RPC stdio transport for the Claude Code MCP protocol. Relies
+Implements the JSON-RPC stdio transport for MCP clients. Relies
 on a running fidelis-server (port 19420 by default) for the actual recall.
 """
 

--- a/tests/scaffold/test_consumer_surface.py
+++ b/tests/scaffold/test_consumer_surface.py
@@ -8,6 +8,8 @@ gates in PUBLISH-PLAN-20260425.md.
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -169,6 +171,104 @@ def test_mcp_uninstall_handles_missing_settings(tmp_path):
     args.settings = str(settings_path)
     rc = cmd_mcp_uninstall(args)
     assert rc == 0  # graceful no-op
+
+
+def test_mcp_codex_install_uses_supported_cli():
+    from fidelis.mcp_cmd import cmd_mcp_install
+
+    args = MagicMock(client="codex", force=False, settings=None)
+    missing = subprocess.CompletedProcess([], 1, stdout="", stderr="No MCP server named 'fidelis' found.")
+    added = subprocess.CompletedProcess([], 0, stdout="Added global MCP server 'fidelis'.", stderr="")
+    with patch("fidelis.mcp_cmd.shutil.which", return_value="/usr/local/bin/codex"), \
+         patch("fidelis.mcp_cmd.subprocess.run", side_effect=[missing, added]) as run:
+        rc = cmd_mcp_install(args)
+
+    assert rc == 0
+    assert run.call_args_list[0].args[0] == [
+        "/usr/local/bin/codex", "mcp", "get", "fidelis", "--json"
+    ]
+    add_command = run.call_args_list[1].args[0]
+    assert add_command[:6] == [
+        "/usr/local/bin/codex", "mcp", "add", "fidelis", "--", sys.executable
+    ]
+    assert add_command[-1].endswith("fidelis/mcp_server.py")
+
+
+def test_mcp_codex_install_is_idempotent_for_fidelis_entry():
+    from fidelis.mcp_cmd import cmd_mcp_install
+
+    entry = {
+        "name": "fidelis",
+        "transport": {
+            "type": "stdio",
+            "command": sys.executable,
+            "args": ["/installed/fidelis/mcp_server.py"],
+        },
+    }
+    found = subprocess.CompletedProcess([], 0, stdout=json.dumps(entry), stderr="")
+    args = MagicMock(client="codex", force=False, settings=None)
+    with patch("fidelis.mcp_cmd.shutil.which", return_value="codex"), \
+         patch("fidelis.mcp_cmd.subprocess.run", return_value=found) as run:
+        rc = cmd_mcp_install(args)
+
+    assert rc == 0
+    assert run.call_count == 1
+
+
+def test_mcp_codex_install_refuses_name_collision():
+    from fidelis.mcp_cmd import cmd_mcp_install
+
+    entry = {
+        "name": "fidelis",
+        "transport": {"type": "stdio", "command": "other-server", "args": []},
+    }
+    found = subprocess.CompletedProcess([], 0, stdout=json.dumps(entry), stderr="")
+    args = MagicMock(client="codex", force=False, settings=None)
+    with patch("fidelis.mcp_cmd.shutil.which", return_value="codex"), \
+         patch("fidelis.mcp_cmd.subprocess.run", return_value=found) as run:
+        rc = cmd_mcp_install(args)
+
+    assert rc == 1
+    assert run.call_count == 1
+
+
+def test_mcp_codex_uninstall_removes_only_fidelis_entry():
+    from fidelis.mcp_cmd import cmd_mcp_uninstall
+
+    entry = {
+        "name": "fidelis",
+        "transport": {
+            "type": "stdio",
+            "command": sys.executable,
+            "args": ["/installed/fidelis/mcp_server.py"],
+        },
+    }
+    found = subprocess.CompletedProcess([], 0, stdout=json.dumps(entry), stderr="")
+    removed = subprocess.CompletedProcess([], 0, stdout="Removed global MCP server 'fidelis'.", stderr="")
+    args = MagicMock(client="codex", settings=None)
+    with patch("fidelis.mcp_cmd.shutil.which", return_value="codex"), \
+         patch("fidelis.mcp_cmd.subprocess.run", side_effect=[found, removed]) as run:
+        rc = cmd_mcp_uninstall(args)
+
+    assert rc == 0
+    assert run.call_args_list[1].args[0] == ["codex", "mcp", "remove", "fidelis"]
+
+
+def test_mcp_codex_install_reports_missing_cli():
+    from fidelis.mcp_cmd import cmd_mcp_install
+
+    args = MagicMock(client="codex", force=False, settings=None)
+    with patch("fidelis.mcp_cmd.shutil.which", return_value=None):
+        assert cmd_mcp_install(args) == 1
+
+
+def test_mcp_codex_rejects_claude_settings_path():
+    from fidelis.mcp_cmd import cmd_mcp_install
+
+    args = MagicMock(client="codex", force=False, settings="/tmp/settings.json")
+    with patch("fidelis.mcp_cmd.shutil.which") as which:
+        assert cmd_mcp_install(args) == 1
+    which.assert_not_called()
 
 
 def test_augment_imports():

--- a/tests/scaffold/test_consumer_surface.py
+++ b/tests/scaffold/test_consumer_surface.py
@@ -195,21 +195,21 @@ def test_mcp_codex_install_uses_supported_cli():
 
 
 def test_mcp_codex_install_is_idempotent_for_fidelis_entry():
-    from fidelis.mcp_cmd import cmd_mcp_install
+    from fidelis import mcp_cmd
 
     entry = {
         "name": "fidelis",
         "transport": {
             "type": "stdio",
             "command": sys.executable,
-            "args": ["/installed/fidelis/mcp_server.py"],
+            "args": [str(mcp_cmd.MCP_SERVER_FILE)],
         },
     }
     found = subprocess.CompletedProcess([], 0, stdout=json.dumps(entry), stderr="")
     args = MagicMock(client="codex", force=False, settings=None)
     with patch("fidelis.mcp_cmd.shutil.which", return_value="codex"), \
          patch("fidelis.mcp_cmd.subprocess.run", return_value=found) as run:
-        rc = cmd_mcp_install(args)
+        rc = mcp_cmd.cmd_mcp_install(args)
 
     assert rc == 0
     assert run.call_count == 1
@@ -232,15 +232,33 @@ def test_mcp_codex_install_refuses_name_collision():
     assert run.call_count == 1
 
 
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"transport": {"command": "/opt/fidelis-proxy", "args": []}},
+        {
+            "transport": {
+                "command": sys.executable,
+                "args": ["/tmp/not-mcp_server.py-backup"],
+            }
+        },
+    ],
+)
+def test_mcp_codex_entry_rejects_near_collisions(entry):
+    from fidelis.mcp_cmd import _is_fidelis_codex_entry
+
+    assert not _is_fidelis_codex_entry(entry)
+
+
 def test_mcp_codex_uninstall_removes_only_fidelis_entry():
-    from fidelis.mcp_cmd import cmd_mcp_uninstall
+    from fidelis import mcp_cmd
 
     entry = {
         "name": "fidelis",
         "transport": {
             "type": "stdio",
             "command": sys.executable,
-            "args": ["/installed/fidelis/mcp_server.py"],
+            "args": [str(mcp_cmd.MCP_SERVER_FILE)],
         },
     }
     found = subprocess.CompletedProcess([], 0, stdout=json.dumps(entry), stderr="")
@@ -248,10 +266,31 @@ def test_mcp_codex_uninstall_removes_only_fidelis_entry():
     args = MagicMock(client="codex", settings=None)
     with patch("fidelis.mcp_cmd.shutil.which", return_value="codex"), \
          patch("fidelis.mcp_cmd.subprocess.run", side_effect=[found, removed]) as run:
-        rc = cmd_mcp_uninstall(args)
+        rc = mcp_cmd.cmd_mcp_uninstall(args)
 
     assert rc == 0
     assert run.call_args_list[1].args[0] == ["codex", "mcp", "remove", "fidelis"]
+
+
+def test_mcp_codex_uninstall_refuses_near_collision():
+    from fidelis.mcp_cmd import cmd_mcp_uninstall
+
+    entry = {
+        "name": "fidelis",
+        "transport": {
+            "type": "stdio",
+            "command": sys.executable,
+            "args": ["/tmp/not-mcp_server.py-backup"],
+        },
+    }
+    found = subprocess.CompletedProcess([], 0, stdout=json.dumps(entry), stderr="")
+    args = MagicMock(client="codex", settings=None)
+    with patch("fidelis.mcp_cmd.shutil.which", return_value="codex"), \
+         patch("fidelis.mcp_cmd.subprocess.run", return_value=found) as run:
+        rc = cmd_mcp_uninstall(args)
+
+    assert rc == 1
+    assert run.call_count == 1
 
 
 def test_mcp_codex_install_reports_missing_cli():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -35,6 +35,26 @@ def test_unrelated_turn_abstains():
     assert plan.retrieval_query is None
 
 
+def test_sentence_starters_do_not_become_project_entities():
+    for utterance in (
+        "Can you write a sorting function?",
+        "Please explain recursion.",
+        "This is interesting.",
+        "How do I install Python?",
+        "Tell me a joke.",
+    ):
+        plan = plan_context(utterance)
+        assert plan.disposition == "abstain", utterance
+        assert plan.entity is None, utterance
+
+
+def test_unknown_entity_can_be_inferred_from_context_cue():
+    plan = plan_context("What is Acme's current status?")
+    assert plan.disposition == "retrieve"
+    assert plan.entity == "Acme"
+    assert plan.evidence_lane == "current"
+
+
 def test_recent_turn_resolves_referent():
     plan = plan_context(
         "What is its current status?",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+
+from fidelis.context import context_packet, plan_context
+from fidelis import mcp_server
+
+
+def test_non_question_recall_request_triggers_context():
+    plan = plan_context("I need to remember our Fidelis work from a few months ago")
+    assert plan.disposition == "retrieve"
+    assert plan.entity == "Fidelis"
+    assert plan.conversational_role == "historical_recall"
+    assert plan.evidence_lane == "historical"
+
+
+def test_same_entity_selects_different_evidence_lanes():
+    maintenance = plan_context("We need to fix Hercules and run its tests")
+    transfer = plan_context("Could Hercules help with symbolic language systems?")
+    assert maintenance.evidence_lane == "maintenance"
+    assert transfer.evidence_lane == "conceptual"
+    assert maintenance.retrieval_query != transfer.retrieval_query
+
+
+def test_casual_known_entity_uses_identity_only_orientation():
+    plan = plan_context("Hercules was a weird name.")
+    assert plan.conversational_role == "identity_only"
+    assert plan.evidence_lane == "identity"
+
+
+def test_unrelated_turn_abstains():
+    plan = plan_context("Write a haiku about the moon")
+    assert plan.disposition == "abstain"
+    assert plan.conversational_role == "no_memory_needed"
+    assert plan.retrieval_query is None
+
+
+def test_recent_turn_resolves_referent():
+    plan = plan_context(
+        "What is its current status?",
+        recent_turns=["We were discussing Fidelis."],
+    )
+    assert plan.entity == "Fidelis"
+    assert plan.evidence_lane == "current"
+
+
+def test_packet_preserves_verbatim_record_and_pointer():
+    record = {
+        "id": "abc",
+        "text": "The exact historical wording.",
+        "score": 0.9,
+        "metadata": {"source_pointer": "session.jsonl:42"},
+    }
+    packet = context_packet(plan_context("Recall Fidelis"), [record])
+    assert packet["records"][0]["text"] == record["text"]
+    assert packet["records"][0]["metadata"] == record["metadata"]
+    assert packet["records"][0]["record_id"] == "abc"
+    assert packet["orientation"]["authority"].startswith("derived index")
+
+
+def test_mcp_orient_abstains_without_server_call(monkeypatch):
+    monkeypatch.setattr(
+        mcp_server,
+        "_http_post",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("no recall")),
+    )
+    packet = json.loads(mcp_server._tool_orient({"utterance": "Write a haiku"}))
+    assert packet["plan"]["disposition"] == "abstain"
+    assert packet["evidence_status"] == "insufficient"
+
+
+def test_mcp_orient_runs_bounded_zero_llm_lane(monkeypatch):
+    calls = []
+
+    def fake_post(path, payload):
+        calls.append((path, payload))
+        return {
+            "memories": [
+                {"id": "one", "text": "Fidelis is a local memory system.", "score": 1.0}
+            ]
+        }
+
+    monkeypatch.setattr(mcp_server, "_http_post", fake_post)
+    packet = json.loads(
+        mcp_server._tool_orient(
+            {"utterance": "We need to maintain Fidelis", "limit": 99}
+        )
+    )
+    assert calls[0][0] == "/recall_hybrid"
+    assert calls[0][1]["tier"] == "zero_llm"
+    assert calls[0][1]["limit"] == 20
+    assert "repository implementation status" in calls[0][1]["text"]
+    assert packet["records"][0]["text"] == "Fidelis is a local memory system."

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -48,6 +48,12 @@ def test_sentence_starters_do_not_become_project_entities():
         assert plan.entity is None, utterance
 
 
+def test_casual_unknown_entity_does_not_trigger_retrieval():
+    plan = plan_context("Docker is good.")
+    assert plan.disposition == "abstain"
+    assert plan.entity is None
+
+
 def test_unknown_entity_can_be_inferred_from_context_cue():
     plan = plan_context("What is Acme's current status?")
     assert plan.disposition == "retrieve"


### PR DESCRIPTION
## Summary

- add supported Codex registration and removal through the `codex mcp` CLI
- add `fidelis_orient`, a bounded MCP tool that selects one evidence lane and returns unmodified records
- conservatively abstain when a turn has no known referent or historical-context cue
- document both capabilities and cover collision, idempotency, uninstall, routing, evidence preservation, and false-positive behavior

## Verification

- `PYTHONPATH=src python3 -m pytest tests/test_context.py tests/scaffold/test_consumer_surface.py -q` — 41 passed
- full CI-runnable pytest suite in an isolated editable install — 497 passed, 1 xpassed
- `python3 -m ruff check src/ tests/` — passed (pre-existing invalid-noqa warnings only)
- `python3 -m compileall -q src/fidelis` — passed
- wheel build and fresh wheel install — passed
- isolated Codex add/get/remove smoke — passed
- installed MCP `initialize` handshake — passed

## Boundary

This PR exposes Fidelis capabilities only. It does not claim that any separate Hermes Reliability plugin already calls `fidelis_orient`, and the orientation packet is explicitly a derived index rather than a synthesized source of truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex support for MCP installation and removal alongside Claude Code.
  * Added the `fidelis_orient` MCP tool for retrieving evidence-based, context-sensitive orientation.
  * Added context planning for maintenance, comparison, conceptual, historical, current, identity, and other conversational needs.
* **Documentation**
  * Updated setup instructions, CLI help, quickstart guidance, and architecture documentation for Codex and the new orientation tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->