### PR TITLE
docs: mark Fidelis 0.0.95 released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Unreleased
 
-## v0.0.95 — unreleased
+## v0.0.95 — 2026-09-02
 
 - Add a portable `fidelis mcp serve` entry point and official MCP Registry
   metadata for `uvx`-based installation.


### PR DESCRIPTION
## Summary

Replace the stale `unreleased` label on the v0.0.95 changelog entry with its actual release date, 2026-09-02.

## Public evidence

- tag `v0.0.95` resolves to public main commit `d6652448ad9caa8517ea622b9271183dcbce5a09`
- PyPI `fidelis-memory==0.0.95` is live and not yanked
- GitHub Release `v0.0.95` is published
- release workflow 33604296482 completed successfully, including PyPI Trusted Publishing and MCP Registry publication
- the Official MCP Registry reports `io.github.hermes-labs-ai/fidelis-memory` version 0.0.95 as active and latest

No package, registry, workflow, or version change is included.

## Verification

- `git diff --check`
- `PYTHONPATH=src python3 -m pytest tests/test_public_install_truth.py -q` — 5 passed