### PR TITLE
docs: expose official MCP Registry install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Stop re-explaining context to your agent. fidelis returns your original notes ve
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Status: pre-release](https://img.shields.io/badge/status-pre--release-orange)](#known-limitations)
 [![CI tests: 368 passing](https://img.shields.io/badge/CI%20tests-368%20passing-brightgreen)](tests/)
+[![Official MCP Registry](https://img.shields.io/badge/MCP%20Registry-active-5b5bd6)](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.hermes-labs-ai%2Ffidelis-memory/versions/0.0.95)
 [![Made by Hermes Labs](https://img.shields.io/badge/made%20by-Hermes%20Labs-purple)](https://hermes-labs.ai)
 
 ```
@@ -58,7 +59,19 @@ fidelis mcp serve             # runs the MCP server over stdio
 
 Linux users swap `brew install ollama` for the equivalent install from [ollama.com](https://ollama.com). [See Requirements](#requirements).
 
-v0.0.94 adds supported Codex MCP installation and context-sensitive orientation.
+Fidelis Memory 0.0.95 is also published in the
+[official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.hermes-labs-ai%2Ffidelis-memory/versions/0.0.95)
+as `io.github.hermes-labs-ai/fidelis-memory`. Registry-aware clients can launch
+the same released server directly from PyPI:
+
+```bash
+uvx --from "fidelis-memory==0.0.95" fidelis mcp serve
+```
+
+This starts the MCP stdio process; run `fidelis init` first when the local
+Fidelis service and store have not already been configured. Version 0.0.94
+introduced supported Codex MCP installation and context-sensitive orientation;
+0.0.95 added the independently discoverable registry release.
 
 ## What you notice immediately
 

--- a/tests/test_public_install_truth.py
+++ b/tests/test_public_install_truth.py
@@ -27,6 +27,23 @@ def test_primary_surfaces_install_the_fidelis_memory_distribution():
         assert 'python3 -m pip install "fidelis-memory==0.0.95"' in text, path
 
 
+def test_readme_exposes_the_exact_official_mcp_registry_release():
+    readme = (ROOT / "README.md").read_text()
+    manifest = json.loads((ROOT / "server.json").read_text())
+    version = manifest["version"]
+    name = manifest["name"]
+    registry_path = name.replace("/", "%2F")
+    registry_url = (
+        "https://registry.modelcontextprotocol.io/v0.1/servers/"
+        f"{registry_path}/versions/{version}"
+    )
+
+    assert registry_url in readme
+    assert f'uvx --from "fidelis-memory=={version}" fidelis mcp serve' in readme
+    assert manifest["packages"][0]["identifier"] == "fidelis-memory"
+    assert manifest["packages"][0]["runtimeHint"] == "uvx"
+
+
 def test_current_readme_links_shipped_benchmark_receipts():
     readme = (ROOT / "README.md").read_text()
     assert "bench/runs/zeroLLM-full-20260424/aggregate.json" not in readme

--- a/tests/test_public_install_truth.py
+++ b/tests/test_public_install_truth.py
@@ -28,20 +28,37 @@ def test_primary_surfaces_install_the_fidelis_memory_distribution():
 
 
 def test_readme_exposes_the_exact_official_mcp_registry_release():
+    """Bind registry discovery prose to the checked-in server manifest."""
     readme = (ROOT / "README.md").read_text()
     manifest = json.loads((ROOT / "server.json").read_text())
     version = manifest["version"]
     name = manifest["name"]
+    package = manifest["packages"][0]
     registry_path = name.replace("/", "%2F")
     registry_url = (
         "https://registry.modelcontextprotocol.io/v0.1/servers/"
         f"{registry_path}/versions/{version}"
     )
+    assert package["version"] == version
+    assert package["registryType"] == "pypi"
+    assert package["runtimeHint"] == "uvx"
+
+    runtime_args = package["runtimeArguments"]
+    assert runtime_args == [
+        {"type": "named", "name": "--from", "value": package["identifier"]}
+    ]
+    package_args = [argument["value"] for argument in package["packageArguments"]]
+    documented_command = " ".join(
+        [
+            package["runtimeHint"],
+            runtime_args[0]["name"],
+            f'"{runtime_args[0]["value"]}=={package["version"]}"',
+            *package_args,
+        ]
+    )
 
     assert registry_url in readme
-    assert f'uvx --from "fidelis-memory=={version}" fidelis mcp serve' in readme
-    assert manifest["packages"][0]["identifier"] == "fidelis-memory"
-    assert manifest["packages"][0]["runtimeHint"] == "uvx"
+    assert documented_command in readme
 
 
 def test_current_readme_links_shipped_benchmark_receipts():


### PR DESCRIPTION
## Outcome

Make the released Fidelis MCP server independently discoverable from the public README and give registry-aware users the exact immutable `uvx` launch path.

## Changes

- link the active official MCP Registry record from a README badge and the Quickstart
- document the exact `fidelis-memory==0.0.95` registry-native launch command
- distinguish the MCP stdio process from the required local service initialization
- bind the README URL, package identifier, version, runtime, and command to `server.json` with a regression test

## Verification

- `pytest -q tests/test_public_install_truth.py` — 6 passed
- `ruff check tests/test_public_install_truth.py` — pass
- official MCP Registry API reports 0.0.95 active
- `uvx --from "fidelis-memory==0.0.95" fidelis mcp serve --help` — pass
- `git diff --check` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Official MCP Registry badge and release information for version 0.0.95.
  * Documented how registry-aware clients can launch the published server.
  * Added setup guidance for unconfigured local services and updated version history.

* **Tests**
  * Added coverage to verify that the README contains the official registry link and installation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->