### PR TITLE
feat: add GitHub Copilot CLI MCP install and uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Unreleased
 
+- Add `fidelis mcp install --client copilot` and `fidelis mcp uninstall
+  --client copilot`, which register the bundled stdio MCP server in GitHub
+  Copilot CLI's documented `mcp-config.json` (`~/.copilot` or `$COPILOT_HOME`)
+  with atomic writes, backups, and ownership checks that preserve unrelated
+  entries. The `copilot` binary is not required at configuration time.
+
 ## v0.0.95 — 2026-09-02
 
 - Add a portable `fidelis mcp serve` entry point and official MCP Registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
   Copilot CLI's documented `mcp-config.json` (`~/.copilot` or `$COPILOT_HOME`)
   with atomic writes, backups, and ownership checks that preserve unrelated
   entries. The `copilot` binary is not required at configuration time.
+  `fidelis mcp uninstall --force` removes an entry that does not look like
+  ours, for the case where the ownership check is wrong.
+- Atomic config rewrites now keep the destination file's permission bits, and
+  a config Fidelis creates is `0600`. Previously every rewrite reset an
+  `mcp-config.json` or `settings.local.json` to the umask default, widening a
+  file that can hold MCP `env` secrets.
+- Config backups no longer overwrite each other when two mutations land in the
+  same second, so an install immediately followed by an uninstall keeps both
+  restore points.
 
 ## v0.0.95 — 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ollama pull nomic-embed-text
 python3 -m pip install "fidelis-memory==0.0.95"
 fidelis init                  # background service (launchd / systemd)
 fidelis watch ~/notes         # auto-ingests markdown
-fidelis mcp install --client codex   # or omit --client for Claude Code
+fidelis mcp install --client codex   # or --client copilot, or omit for Claude Code
 fidelis mcp serve             # runs the MCP server over stdio
 # Restart your agent client. Memory is on.
 ```
@@ -111,9 +111,9 @@ The 3600s window is non-configurable in our current contract.
 
 The non-configurable qualifier survives. So does every other detail you wrote down.
 
-## What this enables in Codex and Claude Code
+## What this enables in Codex, Claude Code, and GitHub Copilot CLI
 
-Once `fidelis mcp install --client codex` (or the default Claude install) is run, ask your agent:
+Once `fidelis mcp install --client codex`, `--client copilot`, or the default Claude install is run, ask your agent:
 
 - *"What did we decide about auth?"*
 - *"What failed last time we tried this migration?"*
@@ -123,6 +123,27 @@ Once `fidelis mcp install --client codex` (or the default Claude install) is run
 The MCP `fidelis_recall` tool gives the agent the original passages before it composes an answer, not paraphrased summaries. The answer can stay grounded in what you wrote, with the qualifiers intact.
 
 > **fidelis retrieves memory without an LLM. Your agent still uses its normal LLM to answer using the retrieved context.** "Zero-LLM" applies to the memory hot path, not to your agent.
+
+### GitHub Copilot CLI
+
+Copilot CLI loads MCP servers from `mcp-config.json` in its configuration
+directory (`~/.copilot` by default, or `$COPILOT_HOME`). Fidelis writes the
+documented stdio entry there atomically, backing up any existing file and
+leaving other servers untouched:
+
+```bash
+fidelis mcp install --client copilot     # writes ~/.copilot/mcp-config.json
+copilot                                  # restart, then /mcp show lists "fidelis"
+fidelis mcp uninstall --client copilot   # removes only the fidelis entry
+```
+
+Use `--settings /path/to/mcp-config.json` to target a different file. The
+`copilot` binary is not required at install time; if you prefer the host CLI,
+the equivalent registration is
+`copilot mcp add fidelis -- "$(python3 -c 'import sys;print(sys.executable)')" "$(python3 -c 'import fidelis.mcp_cmd as m;print(m.MCP_SERVER_FILE)')"`.
+Copilot does not currently expose a hook or automatic-recall mechanism to
+third-party servers, so recall happens when the agent calls the
+`fidelis_recall`, `fidelis_orient`, or `fidelis_health` tools.
 
 ## Use cases & ROI
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ollama pull nomic-embed-text
 python3 -m pip install "fidelis-memory==0.0.95"
 fidelis init                  # background service (launchd / systemd)
 fidelis watch ~/notes         # auto-ingests markdown
-fidelis mcp install --client codex   # or --client copilot, or omit for Claude Code
+fidelis mcp install --client codex   # or omit for Claude Code
 fidelis mcp serve             # runs the MCP server over stdio
 # Restart your agent client. Memory is on.
 ```
@@ -131,9 +131,14 @@ directory (`~/.copilot` by default, or `$COPILOT_HOME`). Fidelis writes the
 documented stdio entry there atomically, backing up any existing file and
 leaving other servers untouched:
 
+> **Unreleased.** `--client copilot` is on `main` and not in the pinned
+> 0.0.95 package installed in the [Quickstart](#quickstart); it ships in the
+> next release. Install from source to use it today.
+
 ```bash
 fidelis mcp install --client copilot     # writes ~/.copilot/mcp-config.json
-copilot                                  # restart, then /mcp show lists "fidelis"
+copilot                                  # restart, then /mcp list shows "fidelis"
+                                         # /mcp show fidelis lists its tools
 fidelis mcp uninstall --client copilot   # removes only the fidelis entry
 ```
 

--- a/agents.md
+++ b/agents.md
@@ -154,7 +154,8 @@ If the upstream LLM (Ollama / extraction model) is unreachable, `/store` and `/a
 2. `fidelis calibrate` — build vocab bridge from corpus (one-time)
 3. `fidelis snapshot` — build compressed index (one-time, rebuild after major changes)
 4. `fidelis init` — install background service (launchd / systemd)
-5. `fidelis mcp install --client codex` — wire Codex as an MCP client, or
+5. `fidelis mcp install --client codex` — wire Codex as an MCP client,
+   `fidelis mcp install --client copilot` for GitHub Copilot CLI, or
    `fidelis mcp install` for Claude Code
 
 If extraction is broken (zer0lint score < 80%), fix that before deploying fidelis. No point filtering garbage.

--- a/docs/full-reference.md
+++ b/docs/full-reference.md
@@ -12,7 +12,8 @@ python3 -m pip install "fidelis-memory==0.0.95"
 fidelis init                  # installs + starts the service (launchd/systemd)
 fidelis watch ~/notes         # auto-ingests markdown/text, polls for new files
 fidelis mcp install           # wires Claude Code MCP integration
-fidelis mcp install --client copilot   # or Codex (--client codex) / GitHub Copilot CLI
+fidelis mcp install --client codex     # wires Codex MCP integration
+# --client copilot wires GitHub Copilot CLI; it is on main, not in 0.0.95
 # Done. Restart Claude Code. Memory is on.
 ```
 

--- a/docs/full-reference.md
+++ b/docs/full-reference.md
@@ -12,6 +12,7 @@ python3 -m pip install "fidelis-memory==0.0.95"
 fidelis init                  # installs + starts the service (launchd/systemd)
 fidelis watch ~/notes         # auto-ingests markdown/text, polls for new files
 fidelis mcp install           # wires Claude Code MCP integration
+fidelis mcp install --client copilot   # or Codex (--client codex) / GitHub Copilot CLI
 # Done. Restart Claude Code. Memory is on.
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -69,7 +69,7 @@ src/fidelis/cli.py        — CLI: recall, query, add, store, seed, snapshot, ca
 src/fidelis/degrade.py    — graceful-degradation queue: atomic writes, per-item retry budget, dead-letter at MAX_ATTEMPTS=5
 src/fidelis/init_cmd.py   — `fidelis init`: installs background service (launchd on macOS, systemd on Linux)
 src/fidelis/watch_cmd.py  — `fidelis watch`: file-system watcher that auto-ingests markdown into the store
-src/fidelis/mcp_cmd.py    — `fidelis mcp install`: wires the MCP server into Claude Code's settings
+src/fidelis/mcp_cmd.py    — `fidelis mcp install`: wires the MCP server into Claude Code, Codex, or GitHub Copilot CLI (--client)
 src/fidelis/augment.py    — Python helper: `augment(question=..., qtype=..., llm_call=...)` for direct integration
 
 ## Key Config Keys
@@ -98,6 +98,8 @@ fidelis init                         install background service (launchd / syste
 fidelis init --uninstall             remove background service
 fidelis watch <dir>                  auto-ingest markdown from a directory
 fidelis mcp install                  wire fidelis MCP tools into Claude Code
+fidelis mcp install --client codex   wire fidelis MCP tools into Codex
+fidelis mcp install --client copilot wire fidelis MCP tools into GitHub Copilot CLI (~/.copilot/mcp-config.json)
 fidelis recall "query"               two-stage recall
 fidelis query "query"                simple vector query
 fidelis recall-hybrid "query"        BM25+dense+RRF retrieval (with --tier zero_llm | filter | flagship)

--- a/llms.txt
+++ b/llms.txt
@@ -100,6 +100,7 @@ fidelis watch <dir>                  auto-ingest markdown from a directory
 fidelis mcp install                  wire fidelis MCP tools into Claude Code
 fidelis mcp install --client codex   wire fidelis MCP tools into Codex
 fidelis mcp install --client copilot wire fidelis MCP tools into GitHub Copilot CLI (~/.copilot/mcp-config.json)
+                                     [unreleased: on main, not in 0.0.95]
 fidelis recall "query"               two-stage recall
 fidelis query "query"                simple vector query
 fidelis recall-hybrid "query"        BM25+dense+RRF retrieval (with --tier zero_llm | filter | flagship)

--- a/src/fidelis/cli.py
+++ b/src/fidelis/cli.py
@@ -331,6 +331,9 @@ def main():
                                  help="MCP client to configure (default: claude)")
     p_mcp_uninstall.add_argument("--settings",
                                  help="Config file to edit (Claude Code settings.local.json or Copilot CLI mcp-config.json)")
+    p_mcp_uninstall.add_argument("--force", action="store_true",
+                                 help="Remove an entry named 'fidelis' even if it doesn't look like ours "
+                                      "(Copilot CLI)")
     p_mcp_uninstall.set_defaults(func=lambda a: sys.exit(_cmd_mcp_uninstall(a)))
 
     args = parser.parse_args()

--- a/src/fidelis/cli.py
+++ b/src/fidelis/cli.py
@@ -4,6 +4,7 @@ fidelis CLI
   fidelis init                       install + start service (launchd/systemd)
   fidelis watch  ~/notes             auto-ingest a directory
   fidelis mcp install --client codex wire Codex MCP integration
+  fidelis mcp install --client copilot wire GitHub Copilot CLI MCP integration
   fidelis recall "query"             two-stage recall via running server
   fidelis query  "query"             simple vector query (no filter)
   fidelis add    "text"              add a memory
@@ -311,21 +312,25 @@ def main():
     p_watch.set_defaults(func=lambda a: sys.exit(_cmd_watch(a)))
 
     # mcp — manage agent-client MCP integration
-    p_mcp = sub.add_parser("mcp", help="Manage Claude Code or Codex MCP integration")
+    p_mcp = sub.add_parser("mcp", help="Manage Claude Code, Codex, or GitHub Copilot CLI MCP integration")
     mcp_sub = p_mcp.add_subparsers(dest="mcp_command", required=True)
     p_mcp_serve = mcp_sub.add_parser("serve", help="Run the MCP server over stdio")
     p_mcp_serve.set_defaults(func=lambda a: sys.exit(_cmd_mcp_serve(a)))
     p_mcp_install = mcp_sub.add_parser("install", help="Install the fidelis MCP server into an agent client")
-    p_mcp_install.add_argument("--client", choices=("claude", "codex"), default="claude",
+    p_mcp_install.add_argument("--client", choices=("claude", "codex", "copilot"), default="claude",
                                help="MCP client to configure (default: claude)")
-    p_mcp_install.add_argument("--settings", help="Path to settings.local.json (default: ~/.claude/settings.local.json)")
+    p_mcp_install.add_argument("--settings",
+                               help="Config file to edit: Claude Code settings.local.json "
+                                    "(default ~/.claude/settings.local.json) or Copilot CLI mcp-config.json "
+                                    "(default ~/.copilot/mcp-config.json, or $COPILOT_HOME)")
     p_mcp_install.add_argument("--force", action="store_true",
                                help="Overwrite an existing 'fidelis' entry even if it doesn't look like ours")
     p_mcp_install.set_defaults(func=lambda a: sys.exit(_cmd_mcp_install(a)))
     p_mcp_uninstall = mcp_sub.add_parser("uninstall", help="Remove the fidelis MCP server from an agent client")
-    p_mcp_uninstall.add_argument("--client", choices=("claude", "codex"), default="claude",
+    p_mcp_uninstall.add_argument("--client", choices=("claude", "codex", "copilot"), default="claude",
                                  help="MCP client to configure (default: claude)")
-    p_mcp_uninstall.add_argument("--settings", help="Path to settings.local.json")
+    p_mcp_uninstall.add_argument("--settings",
+                                 help="Config file to edit (Claude Code settings.local.json or Copilot CLI mcp-config.json)")
     p_mcp_uninstall.set_defaults(func=lambda a: sys.exit(_cmd_mcp_uninstall(a)))
 
     args = parser.parse_args()

--- a/src/fidelis/mcp_cmd.py
+++ b/src/fidelis/mcp_cmd.py
@@ -18,15 +18,59 @@ import time
 from pathlib import Path
 
 
+# An agent MCP config routinely carries an `env` block with API tokens, so a
+# file we create for the first time is owner-only.
+NEW_CONFIG_MODE = 0o600
+
+
 def _atomic_write_json(path: Path, data: dict) -> None:
     """Write JSON atomically: temp file + os.replace. Prevents corruption if
     Claude Code (or any reader) is reading the settings file concurrently.
 
+    os.replace swaps in the temp file's metadata, so the destination's
+    permission bits are read first and reapplied. Without that, rewriting a
+    0600 mcp-config.json would silently widen it to the umask default. A file
+    that does not exist yet is created NEW_CONFIG_MODE.
+
     Uses parent/(name+".tmp") instead of with_suffix to be safe on Python
     3.10/3.11 where with_suffix raised ValueError on multi-dot suffixes."""
+    try:
+        mode = path.stat().st_mode & 0o777
+    except FileNotFoundError:
+        mode = NEW_CONFIG_MODE
     tmp = path.parent / (path.name + ".tmp")
-    tmp.write_text(json.dumps(data, indent=2))
+    # Create restrictively, then widen to the destination mode: the contents
+    # must never pass through a file more readable than the destination.
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(json.dumps(data, indent=2))
+        os.chmod(tmp, mode)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
     os.replace(tmp, path)
+
+
+def _backup(path: Path) -> Path:
+    """Copy `path` aside and return a restore point that never overwrites an
+    earlier one.
+
+    A whole-second timestamp alone collides when two mutations land in the same
+    second — an install followed straight away by an uninstall — which would
+    destroy the older restore point. O_EXCL plus a counter keeps both."""
+    stamp = int(time.time())
+    for attempt in range(1000):
+        suffix = f".bak.{stamp}" if attempt == 0 else f".bak.{stamp}.{attempt}"
+        backup = path.parent / (path.name + suffix)
+        try:
+            os.close(os.open(backup, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600))
+        except FileExistsError:
+            continue
+        shutil.copy(path, backup)
+        return backup
+    raise OSError(f"could not allocate an unused backup name for {path}")
+
 
 DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.local.json"
 MCP_SERVER_NAME = "fidelis"
@@ -183,15 +227,29 @@ def copilot_server_entry() -> dict:
     }
 
 
+def _is_fidelis_server_path(value: object) -> bool:
+    """Return whether a configured argument points at a Fidelis MCP server.
+
+    An exact match against this install is the common case. But a user who
+    registered Fidelis from another environment — a venv since rebuilt, pipx,
+    uvx, a different Python prefix — has the same package laid out under a
+    different root, and refusing to recognize that entry would leave them
+    unable to refresh or remove their own server without --force. Requiring
+    both the packaged file name and its `fidelis` package directory keeps
+    foreign servers out: a near-collision such as
+    ``/tmp/not-mcp_server.py-backup`` still fails."""
+    candidate = Path(str(value)).expanduser()
+    if candidate.resolve() == MCP_SERVER_FILE.resolve():
+        return True
+    return candidate.name == MCP_SERVER_FILE.name and candidate.parent.name == PACKAGE_DIR.name
+
+
 def _is_fidelis_copilot_entry(entry: object) -> bool:
     """Return whether a Copilot MCP entry launches this packaged server."""
     if not isinstance(entry, dict):
         return False
     args = [str(value) for value in entry.get("args", [])]
-    return (
-        len(args) == 1
-        and Path(args[0]).expanduser().resolve() == MCP_SERVER_FILE.resolve()
-    )
+    return len(args) == 1 and _is_fidelis_server_path(args[0])
 
 
 def _load_json_object(path: Path) -> tuple[dict | None, str | None]:
@@ -202,12 +260,6 @@ def _load_json_object(path: Path) -> tuple[dict | None, str | None]:
     if not isinstance(data, dict):
         return None, f"error: {path} must contain a JSON object at the top level"
     return data, None
-
-
-def _backup(path: Path) -> Path:
-    backup = path.with_suffix(f".json.bak.{int(time.time())}")
-    shutil.copy(path, backup)
-    return backup
 
 
 def _cmd_copilot_install(args) -> int:
@@ -257,7 +309,8 @@ def _cmd_copilot_install(args) -> int:
     _atomic_write_json(config_path, config)
     print(f"wrote MCP server '{MCP_SERVER_NAME}' to {config_path}")
     print()
-    print("next: restart Copilot CLI, then run /mcp show to confirm the fidelis server")
+    print("next: restart Copilot CLI, then run /mcp list to see the fidelis server")
+    print("  /mcp show fidelis shows its status and the tools it exposes")
     print("  Copilot may ask you to approve the fidelis tools on first use")
     return 0
 
@@ -277,10 +330,12 @@ def _cmd_copilot_uninstall(args) -> int:
     if not isinstance(mcp_servers, dict) or MCP_SERVER_NAME not in mcp_servers:
         print(f"no '{MCP_SERVER_NAME}' MCP server registered in {config_path}")
         return 0
-    if not _is_fidelis_copilot_entry(mcp_servers[MCP_SERVER_NAME]):
+    if not _is_fidelis_copilot_entry(mcp_servers[MCP_SERVER_NAME]) and not getattr(args, "force", False):
         print(
             f"error: Copilot CLI MCP server '{MCP_SERVER_NAME}' in {config_path} does not appear "
-            "to belong to Fidelis; refusing to remove it",
+            "to belong to Fidelis; refusing to remove it\n"
+            f"  entry: {json.dumps(mcp_servers[MCP_SERVER_NAME])}\n"
+            "  use --force to remove it anyway.",
             file=sys.stderr,
         )
         return 1
@@ -319,9 +374,7 @@ def cmd_mcp_install(args) -> int:
             return 1
 
         # Backup before edit
-        backup = settings_path.with_suffix(f".json.bak.{int(time.time())}")
-        shutil.copy(settings_path, backup)
-        print(f"backed up existing settings to {backup}")
+        print(f"backed up existing settings to {_backup(settings_path)}")
     else:
         settings = {}
         settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -390,9 +443,7 @@ def cmd_mcp_uninstall(args) -> int:
         print(f"no '{MCP_SERVER_NAME}' MCP server registered in {settings_path}")
         return 0
 
-    backup = settings_path.with_suffix(f".json.bak.{int(time.time())}")
-    shutil.copy(settings_path, backup)
-    print(f"backed up to {backup}")
+    print(f"backed up to {_backup(settings_path)}")
 
     del mcp_servers[MCP_SERVER_NAME]
     _atomic_write_json(settings_path, settings)

--- a/src/fidelis/mcp_cmd.py
+++ b/src/fidelis/mcp_cmd.py
@@ -2,7 +2,9 @@
 
 Claude Code configuration is edited atomically with a backup. Codex
 configuration is delegated to the supported ``codex mcp`` CLI so the desktop
-app, CLI, and IDE extension share the same registered server.
+app, CLI, and IDE extension share the same registered server. GitHub Copilot
+CLI configuration is edited atomically with a backup in the documented
+``mcp-config.json`` file (``~/.copilot`` by default, or ``$COPILOT_HOME``).
 """
 
 from __future__ import annotations
@@ -28,6 +30,7 @@ def _atomic_write_json(path: Path, data: dict) -> None:
 
 DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.local.json"
 MCP_SERVER_NAME = "fidelis"
+COPILOT_MCP_CONFIG_NAME = "mcp-config.json"
 
 # Bundled MCP server file lives alongside this module
 PACKAGE_DIR = Path(__file__).resolve().parent
@@ -68,7 +71,7 @@ def _codex_get(codex_bin: str) -> tuple[int, dict | None, str]:
 def _cmd_codex_install(args) -> int:
     if getattr(args, "settings", None):
         print(
-            "error: --settings is only supported for the Claude Code client; "
+            "error: --settings is only supported for the Claude Code and Copilot CLI clients; "
             "Codex uses its shared config through the codex mcp CLI",
             file=sys.stderr,
         )
@@ -146,9 +149,155 @@ def _cmd_codex_uninstall() -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# GitHub Copilot CLI
+#
+# Copilot CLI stores MCP servers in ``mcp-config.json`` under its configuration
+# directory (``~/.copilot`` by default; ``COPILOT_HOME`` overrides it). GitHub
+# documents editing that file directly as a supported alternative to
+# ``copilot mcp add``. Fidelis edits it atomically with a backup so the host CLI
+# does not need to be installed at configuration time and no account state is
+# touched.
+# ---------------------------------------------------------------------------
+
+
+def copilot_config_path(settings: str | None = None) -> Path:
+    """Resolve the Copilot CLI ``mcp-config.json`` path.
+
+    Explicit ``settings`` wins, then ``$COPILOT_HOME/mcp-config.json``, then
+    the documented default ``~/.copilot/mcp-config.json``."""
+    if settings:
+        return Path(settings).expanduser()
+    home = os.environ.get("COPILOT_HOME")
+    base = Path(home).expanduser() if home else Path.home() / ".copilot"
+    return base / COPILOT_MCP_CONFIG_NAME
+
+
+def copilot_server_entry() -> dict:
+    """The exact Copilot CLI stdio entry Fidelis registers."""
+    return {
+        "type": "stdio",
+        "command": sys.executable,
+        "args": [str(MCP_SERVER_FILE)],
+        "tools": ["*"],
+    }
+
+
+def _is_fidelis_copilot_entry(entry: object) -> bool:
+    """Return whether a Copilot MCP entry launches this packaged server."""
+    if not isinstance(entry, dict):
+        return False
+    args = [str(value) for value in entry.get("args", [])]
+    return (
+        len(args) == 1
+        and Path(args[0]).expanduser().resolve() == MCP_SERVER_FILE.resolve()
+    )
+
+
+def _load_json_object(path: Path) -> tuple[dict | None, str | None]:
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        return None, f"error: {path} is not valid JSON: {exc}"
+    if not isinstance(data, dict):
+        return None, f"error: {path} must contain a JSON object at the top level"
+    return data, None
+
+
+def _backup(path: Path) -> Path:
+    backup = path.with_suffix(f".json.bak.{int(time.time())}")
+    shutil.copy(path, backup)
+    return backup
+
+
+def _cmd_copilot_install(args) -> int:
+    if not MCP_SERVER_FILE.exists():
+        print(
+            f"error: bundled MCP server not found at {MCP_SERVER_FILE}\n"
+            "  this install appears incomplete; reinstall Hermes Labs Fidelis "
+            "from its tagged GitHub source (see README)",
+            file=sys.stderr,
+        )
+        return 1
+
+    config_path = copilot_config_path(getattr(args, "settings", None))
+    if config_path.exists():
+        config, error = _load_json_object(config_path)
+        if error:
+            print(error, file=sys.stderr)
+            return 1
+    else:
+        config = {}
+
+    mcp_servers = config.setdefault("mcpServers", {})
+    if not isinstance(mcp_servers, dict):
+        print(f"error: 'mcpServers' in {config_path} is not a JSON object", file=sys.stderr)
+        return 1
+
+    existing = mcp_servers.get(MCP_SERVER_NAME)
+    entry = copilot_server_entry()
+    if existing == entry:
+        print(f"Copilot CLI MCP server '{MCP_SERVER_NAME}' is already configured in {config_path}; nothing to change")
+        return 0
+    if existing is not None and not _is_fidelis_copilot_entry(existing) and not args.force:
+        print(
+            f"error: a non-fidelis Copilot CLI MCP server named '{MCP_SERVER_NAME}' already exists in {config_path}\n"
+            f"  entry: {json.dumps(existing)}\n"
+            "  refusing to overwrite. Use --force to replace it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if config_path.exists():
+        print(f"backed up existing config to {_backup(config_path)}")
+    else:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    mcp_servers[MCP_SERVER_NAME] = entry
+    _atomic_write_json(config_path, config)
+    print(f"wrote MCP server '{MCP_SERVER_NAME}' to {config_path}")
+    print()
+    print("next: restart Copilot CLI, then run /mcp show to confirm the fidelis server")
+    print("  Copilot may ask you to approve the fidelis tools on first use")
+    return 0
+
+
+def _cmd_copilot_uninstall(args) -> int:
+    config_path = copilot_config_path(getattr(args, "settings", None))
+    if not config_path.exists():
+        print(f"no Copilot CLI config at {config_path}; nothing to uninstall")
+        return 0
+
+    config, error = _load_json_object(config_path)
+    if error:
+        print(error, file=sys.stderr)
+        return 1
+
+    mcp_servers = config.get("mcpServers")
+    if not isinstance(mcp_servers, dict) or MCP_SERVER_NAME not in mcp_servers:
+        print(f"no '{MCP_SERVER_NAME}' MCP server registered in {config_path}")
+        return 0
+    if not _is_fidelis_copilot_entry(mcp_servers[MCP_SERVER_NAME]):
+        print(
+            f"error: Copilot CLI MCP server '{MCP_SERVER_NAME}' in {config_path} does not appear "
+            "to belong to Fidelis; refusing to remove it",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"backed up to {_backup(config_path)}")
+    del mcp_servers[MCP_SERVER_NAME]
+    _atomic_write_json(config_path, config)
+    print(f"removed '{MCP_SERVER_NAME}' MCP server from {config_path}")
+    return 0
+
+
 def cmd_mcp_install(args) -> int:
-    if getattr(args, "client", "claude") == "codex":
+    client = getattr(args, "client", "claude")
+    if client == "codex":
         return _cmd_codex_install(args)
+    if client == "copilot":
+        return _cmd_copilot_install(args)
 
     settings_path = Path(args.settings).expanduser() if args.settings else DEFAULT_SETTINGS
 
@@ -211,15 +360,18 @@ def cmd_mcp_install(args) -> int:
 
 
 def cmd_mcp_uninstall(args) -> int:
-    if getattr(args, "client", "claude") == "codex":
+    client = getattr(args, "client", "claude")
+    if client == "codex":
         if getattr(args, "settings", None):
             print(
-                "error: --settings is only supported for the Claude Code client; "
+                "error: --settings is only supported for the Claude Code and Copilot CLI clients; "
                 "Codex uses its shared config through the codex mcp CLI",
                 file=sys.stderr,
             )
             return 1
         return _cmd_codex_uninstall()
+    if client == "copilot":
+        return _cmd_copilot_uninstall(args)
 
     settings_path = Path(args.settings).expanduser() if args.settings else DEFAULT_SETTINGS
 

--- a/tests/test_mcp_copilot.py
+++ b/tests/test_mcp_copilot.py
@@ -16,6 +16,7 @@ import pytest
 from fidelis import cli, mcp_cmd
 from fidelis.mcp_cmd import (
     MCP_SERVER_FILE,
+    _is_fidelis_server_path,
     cmd_mcp_install,
     cmd_mcp_uninstall,
     copilot_config_path,
@@ -200,3 +201,157 @@ def test_cli_accepts_copilot_client(tmp_path, monkeypatch):
         cli.main()
     assert exc.value.code == 0
     assert "fidelis" not in _read(config)["mcpServers"]
+
+
+def _mode(path: Path) -> int:
+    return path.stat().st_mode & 0o777
+
+
+# --- file permissions -------------------------------------------------------
+
+
+def test_install_creates_a_new_config_owner_only(tmp_path):
+    """A config Fidelis creates may later gain an `env` block with API tokens."""
+    config = tmp_path / "mcp-config.json"
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert _mode(config) == 0o600
+
+
+def test_install_and_uninstall_preserve_existing_config_permissions(tmp_path):
+    """os.replace swaps in the temp file's metadata; the rewrite must not widen
+    a config the user (or Copilot CLI) locked down."""
+    config = tmp_path / "mcp-config.json"
+    config.write_text(json.dumps({"mcpServers": {}}))
+    config.chmod(0o600)
+
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert _mode(config) == 0o600
+
+    assert cmd_mcp_uninstall(_args(str(config))) == 0
+    assert _mode(config) == 0o600
+
+
+def test_rewrite_keeps_a_deliberately_group_readable_config(tmp_path):
+    config = tmp_path / "mcp-config.json"
+    config.write_text(json.dumps({"mcpServers": {}}))
+    config.chmod(0o640)
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert _mode(config) == 0o640
+
+
+def test_no_temp_file_survives_a_write(tmp_path):
+    config = tmp_path / "mcp-config.json"
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+# --- backups ----------------------------------------------------------------
+
+
+def test_two_mutations_in_one_second_keep_both_restore_points(tmp_path, monkeypatch):
+    """A whole-second stamp alone would let the uninstall backup clobber the
+    install backup, destroying the only copy of the user's original file."""
+    monkeypatch.setattr(mcp_cmd.time, "time", lambda: 1_700_000_000.0)
+    config = tmp_path / "mcp-config.json"
+    original = {"mcpServers": {"github": {"type": "http", "url": "https://example.invalid"}}}
+    config.write_text(json.dumps(original))
+
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert cmd_mcp_uninstall(_args(str(config))) == 0
+
+    backups = _backups(config)
+    assert len(backups) == 2
+    contents = [_read(backup) for backup in backups]
+    assert original in contents
+    assert any("fidelis" in snapshot["mcpServers"] for snapshot in contents)
+
+
+# --- ownership across environments ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/opt/homebrew/lib/python3.12/site-packages/fidelis/mcp_server.py",
+        "~/.local/pipx/venvs/fidelis-memory/lib/python3.11/site-packages/fidelis/mcp_server.py",
+    ],
+)
+def test_a_fidelis_install_from_another_environment_is_recognized_as_ours(path):
+    assert _is_fidelis_server_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/tmp/not-mcp_server.py-backup",
+        "/opt/other-server/mcp_server.py",
+        "/opt/fidelis/server.py",
+        "some-other-fidelis",
+    ],
+)
+def test_foreign_servers_are_not_mistaken_for_ours(path):
+    assert not _is_fidelis_server_path(path)
+
+
+def test_install_refreshes_an_entry_written_by_another_environment(tmp_path):
+    """The user's own prior install must be refreshable without --force even
+    when its interpreter and package root are gone."""
+    config = tmp_path / "mcp-config.json"
+    stale = {
+        "type": "stdio",
+        "command": "/opt/homebrew/opt/python@3.12/bin/python3.12",
+        "args": ["/opt/homebrew/lib/python3.12/site-packages/fidelis/mcp_server.py"],
+        "tools": ["*"],
+    }
+    config.write_text(json.dumps({"mcpServers": {"fidelis": stale}}))
+
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert _read(config)["mcpServers"]["fidelis"] == copilot_server_entry()
+
+
+def test_uninstall_removes_an_entry_written_by_another_environment(tmp_path):
+    config = tmp_path / "mcp-config.json"
+    stale = {
+        "type": "stdio",
+        "command": "/opt/homebrew/opt/python@3.12/bin/python3.12",
+        "args": ["/opt/homebrew/lib/python3.12/site-packages/fidelis/mcp_server.py"],
+    }
+    config.write_text(json.dumps({"mcpServers": {"fidelis": stale}}))
+
+    assert cmd_mcp_uninstall(_args(str(config))) == 0
+    assert "fidelis" not in _read(config)["mcpServers"]
+
+
+def test_uninstall_force_removes_a_foreign_entry(tmp_path, capsys):
+    """The ownership check is a guess; --force is the documented escape."""
+    config = tmp_path / "mcp-config.json"
+    foreign = {"type": "stdio", "command": "npx", "args": ["other"]}
+    config.write_text(json.dumps({"mcpServers": {"fidelis": foreign, "keep": {"type": "http"}}}))
+
+    assert cmd_mcp_uninstall(_args(str(config))) == 1
+    assert "use --force" in capsys.readouterr().err
+
+    assert cmd_mcp_uninstall(_args(str(config), force=True)) == 0
+    after = _read(config)
+    assert "fidelis" not in after["mcpServers"]
+    assert after["mcpServers"]["keep"] == {"type": "http"}
+
+
+# --- remaining input branches ------------------------------------------------
+
+
+def test_install_rejects_a_non_object_config(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    config.write_text(json.dumps(["not", "an", "object"]))
+    assert cmd_mcp_install(_args(str(config))) == 1
+    assert "JSON object at the top level" in capsys.readouterr().err
+    assert _read(config) == ["not", "an", "object"]
+
+
+def test_uninstall_rejects_invalid_json_without_writing(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    config.write_text("{not json")
+    assert cmd_mcp_uninstall(_args(str(config))) == 1
+    assert config.read_text() == "{not json"
+    assert "not valid JSON" in capsys.readouterr().err
+    assert not _backups(config)

--- a/tests/test_mcp_copilot.py
+++ b/tests/test_mcp_copilot.py
@@ -1,0 +1,202 @@
+"""Regression tests for `fidelis mcp install|uninstall --client copilot`.
+
+GitHub Copilot CLI reads MCP servers from ``mcp-config.json`` under
+``~/.copilot`` (or ``$COPILOT_HOME``). These tests exercise the documented
+file shape without touching the real home directory or requiring the
+``copilot`` binary.
+"""
+
+import json
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from fidelis import cli, mcp_cmd
+from fidelis.mcp_cmd import (
+    MCP_SERVER_FILE,
+    cmd_mcp_install,
+    cmd_mcp_uninstall,
+    copilot_config_path,
+    copilot_server_entry,
+)
+
+
+def _args(settings: str | None, force: bool = False, client: str = "copilot") -> Namespace:
+    return Namespace(client=client, settings=settings, force=force)
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _backups(path: Path) -> list[Path]:
+    return sorted(path.parent.glob(f"{path.stem}.json.bak.*"))
+
+
+def test_install_writes_documented_stdio_entry(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    assert cmd_mcp_install(_args(str(config))) == 0
+
+    data = _read(config)
+    entry = data["mcpServers"]["fidelis"]
+    assert entry == {
+        "type": "stdio",
+        "command": sys.executable,
+        "args": [str(MCP_SERVER_FILE)],
+        "tools": ["*"],
+    }
+    assert Path(entry["args"][0]).is_file()
+    assert entry == copilot_server_entry()
+    assert not _backups(config), "fresh install must not create a backup"
+    out = capsys.readouterr().out
+    assert str(config) in out
+    assert "restart Copilot CLI" in out
+
+
+def test_install_preserves_unrelated_servers_and_backs_up(tmp_path):
+    config = tmp_path / "mcp-config.json"
+    original = {
+        "mcpServers": {
+            "github": {"type": "http", "url": "https://api.githubcopilot.com/mcp/", "tools": ["*"]},
+        },
+        "unrelatedKey": {"keep": True},
+    }
+    config.write_text(json.dumps(original))
+
+    assert cmd_mcp_install(_args(str(config))) == 0
+
+    data = _read(config)
+    assert data["mcpServers"]["github"] == original["mcpServers"]["github"]
+    assert data["unrelatedKey"] == {"keep": True}
+    assert "fidelis" in data["mcpServers"]
+    backups = _backups(config)
+    assert len(backups) == 1
+    assert _read(backups[0]) == original
+
+
+def test_install_is_idempotent(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    assert cmd_mcp_install(_args(str(config))) == 0
+    first = config.read_text()
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert config.read_text() == first
+    assert not _backups(config), "no-op reinstall must not churn backups"
+    assert "nothing to change" in capsys.readouterr().out
+
+
+def test_install_refuses_foreign_entry_without_force(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    foreign = {"type": "stdio", "command": "npx", "args": ["some-other-fidelis"], "tools": ["*"]}
+    config.write_text(json.dumps({"mcpServers": {"fidelis": foreign}}))
+
+    assert cmd_mcp_install(_args(str(config))) == 1
+    assert _read(config)["mcpServers"]["fidelis"] == foreign
+    assert not _backups(config)
+    assert "refusing to overwrite" in capsys.readouterr().err
+
+    assert cmd_mcp_install(_args(str(config), force=True)) == 0
+    assert _read(config)["mcpServers"]["fidelis"] == copilot_server_entry()
+
+
+def test_install_updates_stale_fidelis_entry_in_place(tmp_path):
+    """An older fidelis entry (different interpreter / missing tools) is ours; refresh it."""
+    config = tmp_path / "mcp-config.json"
+    stale = {"type": "local", "command": "/old/python", "args": [str(MCP_SERVER_FILE)]}
+    config.write_text(json.dumps({"mcpServers": {"fidelis": stale}}))
+
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert _read(config)["mcpServers"]["fidelis"] == copilot_server_entry()
+    assert len(_backups(config)) == 1
+
+
+def test_install_rejects_invalid_json_without_writing(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    config.write_text("{not json")
+    assert cmd_mcp_install(_args(str(config))) == 1
+    assert config.read_text() == "{not json"
+    assert "not valid JSON" in capsys.readouterr().err
+
+
+def test_install_rejects_non_object_mcp_servers(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    config.write_text(json.dumps({"mcpServers": []}))
+    assert cmd_mcp_install(_args(str(config))) == 1
+    assert "not a JSON object" in capsys.readouterr().err
+
+
+def test_uninstall_removes_only_fidelis(tmp_path):
+    config = tmp_path / "mcp-config.json"
+    assert cmd_mcp_install(_args(str(config))) == 0
+    data = _read(config)
+    data["mcpServers"]["github"] = {"type": "http", "url": "https://api.githubcopilot.com/mcp/"}
+    config.write_text(json.dumps(data))
+
+    assert cmd_mcp_uninstall(_args(str(config))) == 0
+    after = _read(config)
+    assert "fidelis" not in after["mcpServers"]
+    assert after["mcpServers"]["github"]["type"] == "http"
+    assert len(_backups(config)) == 1
+
+
+def test_uninstall_refuses_foreign_entry(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    foreign = {"type": "stdio", "command": "npx", "args": ["other"]}
+    config.write_text(json.dumps({"mcpServers": {"fidelis": foreign}}))
+    assert cmd_mcp_uninstall(_args(str(config))) == 1
+    assert _read(config)["mcpServers"]["fidelis"] == foreign
+    assert "refusing to remove" in capsys.readouterr().err
+
+
+def test_uninstall_without_config_or_entry_is_a_noop(tmp_path, capsys):
+    config = tmp_path / "mcp-config.json"
+    assert cmd_mcp_uninstall(_args(str(config))) == 0
+    assert "nothing to uninstall" in capsys.readouterr().out
+
+    config.write_text(json.dumps({"mcpServers": {}}))
+    assert cmd_mcp_uninstall(_args(str(config))) == 0
+    assert _read(config) == {"mcpServers": {}}
+
+
+def test_default_path_honors_copilot_home(tmp_path, monkeypatch):
+    monkeypatch.delenv("COPILOT_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+    assert copilot_config_path(None) == tmp_path / "home" / ".copilot" / "mcp-config.json"
+
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path / "custom"))
+    assert copilot_config_path(None) == tmp_path / "custom" / "mcp-config.json"
+    assert copilot_config_path(str(tmp_path / "explicit.json")) == tmp_path / "explicit.json"
+
+
+def test_install_under_copilot_home_creates_directory(tmp_path, monkeypatch):
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path / "copilot-home"))
+    assert cmd_mcp_install(_args(None)) == 0
+    config = tmp_path / "copilot-home" / "mcp-config.json"
+    assert config.is_file()
+    assert _read(config)["mcpServers"]["fidelis"] == copilot_server_entry()
+    assert cmd_mcp_uninstall(_args(None)) == 0
+    assert "fidelis" not in _read(config)["mcpServers"]
+
+
+def test_install_never_touches_claude_or_codex_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(mcp_cmd, "DEFAULT_SETTINGS", tmp_path / "claude-settings.json")
+    monkeypatch.setattr(mcp_cmd, "_codex_cli", lambda: pytest.fail("codex CLI must not be invoked"))
+    config = tmp_path / "mcp-config.json"
+    assert cmd_mcp_install(_args(str(config))) == 0
+    assert not (tmp_path / "claude-settings.json").exists()
+
+
+def test_cli_accepts_copilot_client(tmp_path, monkeypatch):
+    config = tmp_path / "mcp-config.json"
+    monkeypatch.setattr(sys, "argv", ["fidelis", "mcp", "install", "--client", "copilot", "--settings", str(config)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0
+    assert _read(config)["mcpServers"]["fidelis"] == copilot_server_entry()
+
+    monkeypatch.setattr(sys, "argv", ["fidelis", "mcp", "uninstall", "--client", "copilot", "--settings", str(config)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0
+    assert "fidelis" not in _read(config)["mcpServers"]


### PR DESCRIPTION
## Outcome

`fidelis mcp install --client copilot` registers the bundled stdio MCP server in GitHub Copilot CLI's documented `mcp-config.json` (`~/.copilot`, or `$COPILOT_HOME`), and `fidelis mcp uninstall --client copilot` removes it. The `copilot` binary is not required at configuration time, and no account state is touched.

## Changes

- Add `mcp install --client copilot` and `mcp uninstall --client copilot`: atomic writes, timestamped backups, and an ownership check that refuses to overwrite or remove an entry that is not ours (`uninstall --force` overrides the check).
- Atomic config rewrites keep the destination file's permission bits, and a config Fidelis creates is `0600`, since `mcp-config.json` can hold MCP `env` secrets.
- Config backups no longer overwrite each other when two mutations land in the same second.
- Document the path in README, agents.md, docs/full-reference.md, llms.txt, and the changelog.

## Verification

- `tests/test_mcp_copilot.py` covers install, idempotent reinstall, stale-entry refresh, foreign-entry refusal, invalid JSON, uninstall, `COPILOT_HOME` resolution, and CLI argument acceptance.
- Wheel built from this head, installed into a fresh venv, and exercised against a scratch `COPILOT_HOME`: install, idempotent rerun, uninstall with unrelated config preserved and two rapid backups kept distinct.
- Ruff and `git diff --check` are clean; the CI matrix runs the full suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GitHub Copilot CLI support for MCP installation and removal.
  - Supports custom settings locations, including `COPILOT_HOME`, while preserving unrelated configuration entries.
  - Added safe backups and forced removal options for entries that cannot be verified as Fidelis-managed.

- **Bug Fixes**
  - Preserves existing configuration permissions and applies secure permissions to newly created files.
  - Prevents configuration corruption during updates and avoids backup filename collisions.

- **Documentation**
  - Updated CLI help, README, reference documentation, and agent guidance with Copilot setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->